### PR TITLE
[FEATURE] Design and Deploy Enterprise Grade GKE Cluster and Workload

### DIFF
--- a/.github/workflows/sandbox-validation.yml
+++ b/.github/workflows/sandbox-validation.yml
@@ -1,15 +1,65 @@
-name: Sandbox Validation Placeholder
+name: Sandbox Validation
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
 jobs:
-  build:
+  validate-kcc:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run a one-line script
-        run: echo "This is a placeholder for sandbox validation."
+      
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+          
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        
+      - name: Get GKE Credentials (Management)
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: repo-agent
+          location: us-central1
+          
+      - name: Parameterize Manifests
+        run: |
+          PROJECT_ID="gca-gke-2025"
+          UNIQUE_NAME="ent-cls-pr-${{ github.event.pull_request.number }}"
+          
+          sed -i "s/YOUR_PROJECT_ID/$PROJECT_ID/g" templates/6-enterprise-gke/cluster/*.yaml
+          sed -i "s/enterprise-cluster/$UNIQUE_NAME/g" templates/6-enterprise-gke/cluster/*.yaml
+          
+      - name: Deploy KCC Template
+        run: |
+          kubectl apply -f templates/6-enterprise-gke/cluster/
+          
+      - name: Wait for Cluster Readiness
+        run: |
+          UNIQUE_NAME="ent-cls-pr-${{ github.event.pull_request.number }}"
+          # Wait up to 20 minutes for the cluster to be ready
+          kubectl wait --for=condition=Ready containercluster/$UNIQUE_NAME --timeout=20m
+          
+      - name: Get Credentials for New Cluster
+        run: |
+          UNIQUE_NAME="ent-cls-pr-${{ github.event.pull_request.number }}"
+          gcloud container clusters get-credentials $UNIQUE_NAME --region us-central1 --project gca-gke-2025
+          
+      - name: Deploy Workload (Helm)
+        run: |
+          cd templates/6-enterprise-gke/workload
+          helm install my-workload . --wait --timeout 5m
+          
+      - name: Verify Workload
+        run: |
+          kubectl get pods --all-namespaces
+          
+      - name: Tear Down
+        if: always()
+        run: |
+          # Switch back to management cluster to delete
+          gcloud container clusters get-credentials repo-agent --region us-central1 --project gca-gke-2025
+          UNIQUE_NAME="ent-cls-pr-${{ github.event.pull_request.number }}"
+          kubectl delete containercluster $UNIQUE_NAME --ignore-not-found

--- a/templates/6-enterprise-gke/README.md
+++ b/templates/6-enterprise-gke/README.md
@@ -1,0 +1,38 @@
+# Enterprise GKE Cluster and Workload Template
+
+This template provides an Enterprise-grade Google Kubernetes Engine (GKE) cluster via Google Cloud Config Connector (KCC) manifests, and a corresponding production-ready Helm chart workload.
+
+## Features
+
+### GKE Cluster
+- **Regional Deployment:** High availability across zones (`location: us-central1`).
+- **Private Cluster:** Nodes with internal IP addresses only.
+- **Workload Identity:** Allows Kubernetes service accounts to act as Google IAM service accounts without downloading keys.
+- **Network Policies:** Enforces network boundaries and isolation.
+- **Binary Authorization:** Enforces signature validation and trusted container registries.
+- **Security Posture & Monitoring:** Deep integration with Google Cloud Operations Suite and the Security Posture Dashboard.
+
+### Workload (Helm Chart)
+- **High Availability:** Pod Anti-Affinity, Horizontal Pod Autoscaler (HPA), and Pod Disruption Budgets (PDB).
+- **Security Context:** Runs as a non-root user (UID 1000), drops ALL Linux capabilities, and uses a read-only root filesystem.
+- **Probes:** Configured Liveness and Readiness probes.
+- **Resource Limits:** Defined CPU and Memory requests/limits.
+- **Secrets Management:** Integrates with Google Secret Manager via the Secrets Store CSI driver.
+- **Network Policy:** Restricts ingress and egress traffic at the pod level.
+
+## Usage
+
+1. **Configure KCC Manifests:**
+   - Update `YOUR_PROJECT_ID` in `cluster/cluster.yaml` and `cluster/nodepool.yaml`.
+   - Update the network and subnetwork references.
+   - Apply the cluster manifests:
+     ```sh
+     kubectl apply -f cluster/
+     ```
+
+2. **Deploy the Workload:**
+   - Modify values in `workload/values.yaml` (e.g., project ID, service account details).
+   - Install using Helm:
+     ```sh
+     helm install enterprise-app ./workload -f workload/values.yaml
+     ```

--- a/templates/6-enterprise-gke/cluster/cluster.yaml
+++ b/templates/6-enterprise-gke/cluster/cluster.yaml
@@ -1,0 +1,47 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: enterprise-cluster
+  namespace: default
+  annotations:
+    # Replace with your GCP Project ID
+    cnrm.cloud.google.com/project-id: "YOUR_PROJECT_ID"
+spec:
+  location: us-central1
+  # The cluster is regional, so node count is per-zone
+  initialNodeCount: 1
+  networkingMode: VPC_NATIVE
+  networkRef:
+    # Replace with your network
+    name: "projects/YOUR_PROJECT_ID/global/networks/default"
+  subnetworkRef:
+    # Replace with your subnetwork
+    name: "projects/YOUR_PROJECT_ID/regions/us-central1/subnetworks/default"
+  ipAllocationPolicy:
+    clusterIpv4CidrBlock: /14
+    servicesIpv4CidrBlock: /20
+  privateClusterConfig:
+    enablePrivateNodes: true
+    enablePrivateEndpoint: false
+    masterIpv4CidrBlock: "172.16.0.0/28"
+  workloadIdentityConfig:
+    workloadPool: "YOUR_PROJECT_ID.svc.id.goog"
+  networkPolicy:
+    enabled: true
+    provider: CALICO
+  binaryAuthorization:
+    evaluationMode: PROJECT_SINGLETON_POLICY_ENFORCE
+  loggingConfig:
+    enableComponents:
+      - SYSTEM_COMPONENTS
+      - WORKLOADS
+  monitoringConfig:
+    enableComponents:
+      - SYSTEM_COMPONENTS
+    managedPrometheus:
+      enabled: true
+  securityPostureConfig:
+    mode: BASIC
+    vulnerabilityMode: VULNERABILITY_ENTERPRISE
+  releaseChannel:
+    channel: REGULAR

--- a/templates/6-enterprise-gke/cluster/nodepool.yaml
+++ b/templates/6-enterprise-gke/cluster/nodepool.yaml
@@ -1,0 +1,30 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerNodePool
+metadata:
+  name: enterprise-pool
+  namespace: default
+  annotations:
+    # Replace with your GCP Project ID
+    cnrm.cloud.google.com/project-id: "YOUR_PROJECT_ID"
+spec:
+  location: us-central1
+  clusterRef:
+    name: enterprise-cluster
+  nodeCount: 1
+  autoscaling:
+    minNodeCount: 1
+    maxNodeCount: 5
+  management:
+    autoRepair: true
+    autoUpgrade: true
+  nodeConfig:
+    machineType: e2-standard-4
+    diskSizeGb: 100
+    diskType: pd-standard
+    oauthScopes:
+      - https://www.googleapis.com/auth/cloud-platform
+    workloadMetadataConfig:
+      mode: GKE_METADATA
+    shieldedInstanceConfig:
+      enableSecureBoot: true
+      enableIntegrityMonitoring: true

--- a/templates/6-enterprise-gke/workload/Chart.yaml
+++ b/templates/6-enterprise-gke/workload/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: enterprise-workload
+description: A Helm chart for an enterprise-ready Kubernetes workload
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/templates/6-enterprise-gke/workload/templates/_helpers.tpl
+++ b/templates/6-enterprise-gke/workload/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "enterprise-workload.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "enterprise-workload.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "enterprise-workload.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "enterprise-workload.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/templates/6-enterprise-gke/workload/templates/configmap.yaml
+++ b/templates/6-enterprise-gke/workload/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "enterprise-workload.fullname" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  {{- range $key, $val := .Values.config }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/templates/6-enterprise-gke/workload/templates/deployment.yaml
+++ b/templates/6-enterprise-gke/workload/templates/deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "enterprise-workload.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ include "enterprise-workload.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - {{ include "enterprise-workload.name" . }}
+                topologyKey: kubernetes.io/hostname
+            - weight: 50
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/name
+                      operator: In
+                      values:
+                        - {{ include "enterprise-workload.name" . }}
+                topologyKey: topology.kubernetes.io/zone
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "enterprise-workload.fullname" . }}-config
+          {{- if .Values.secrets.enabled }}
+          volumeMounts:
+            - name: secrets-volume
+              mountPath: "/mnt/secrets"
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            - name: run
+              mountPath: /var/run
+            - name: cache
+              mountPath: /var/cache/nginx
+          {{- else }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: run
+              mountPath: /var/run
+            - name: cache
+              mountPath: /var/cache/nginx
+          {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        - name: cache
+          emptyDir: {}
+        {{- if .Values.secrets.enabled }}
+        - name: secrets-volume
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: {{ .Values.secrets.providerClass }}
+        {{- end }}

--- a/templates/6-enterprise-gke/workload/templates/hpa.yaml
+++ b/templates/6-enterprise-gke/workload/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "enterprise-workload.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "enterprise-workload.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/templates/6-enterprise-gke/workload/templates/networkpolicy.yaml
+++ b/templates/6-enterprise-gke/workload/templates/networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "enterprise-workload.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: default
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: 53
+        - protocol: UDP
+          port: 53
+    # Allow egress to GCP APIs for Secret Manager and other services if needed
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443
+{{- end }}

--- a/templates/6-enterprise-gke/workload/templates/pdb.yaml
+++ b/templates/6-enterprise-gke/workload/templates/pdb.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "enterprise-workload.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/templates/6-enterprise-gke/workload/templates/secretproviderclass.yaml
+++ b/templates/6-enterprise-gke/workload/templates/secretproviderclass.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.secrets.enabled }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .Values.secrets.providerClass }}
+  labels:
+    app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+      - resourceName: "projects/{{ .Values.secrets.gcpProjectId }}/secrets/{{ .Values.secrets.secretName }}/versions/{{ .Values.secrets.secretVersion }}"
+        path: "secret.data"
+{{- end }}

--- a/templates/6-enterprise-gke/workload/templates/service.yaml
+++ b/templates/6-enterprise-gke/workload/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "enterprise-workload.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/6-enterprise-gke/workload/templates/serviceaccount.yaml
+++ b/templates/6-enterprise-gke/workload/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "enterprise-workload.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "enterprise-workload.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ .Values.serviceAccount.gcpServiceAccount }}
+{{- end }}

--- a/templates/6-enterprise-gke/workload/values.yaml
+++ b/templates/6-enterprise-gke/workload/values.yaml
@@ -1,0 +1,65 @@
+replicaCount: 3
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  tag: "1.25.3"
+
+serviceAccount:
+  create: true
+  name: "enterprise-workload-sa"
+  # Annotate with GCP Service Account for Workload Identity
+  gcpServiceAccount: "YOUR_GCP_SA@YOUR_PROJECT_ID.iam.gserviceaccount.com"
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 3000
+  fsGroup: 2000
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+
+pdb:
+  enabled: true
+  minAvailable: 2
+
+networkPolicy:
+  enabled: true
+
+# ConfigMap properties
+config:
+  LOG_LEVEL: "info"
+  ENVIRONMENT: "production"
+
+# Secret Manager CSI Driver setup
+secrets:
+  enabled: true
+  providerClass: "enterprise-secrets"
+  gcpProjectId: "YOUR_PROJECT_ID"
+  secretName: "enterprise-workload-secret"
+  secretVersion: "latest"


### PR DESCRIPTION
Fixes #6.

This PR was generated by **Overseer** (powered by the gemini-3.1-pro-preview model).

It adds the enterprise-grade GKE cluster and workload templates according to the issue requirements.
The cluster utilizes Google Cloud Config Connector (KCC) manifests to define a regional deployment, private nodes, workload identity, network policies, binary authorization, and security posture monitoring.
The workload utilizes a Helm chart to demonstrate production-readiness, including explicit resource requests/limits, pod anti-affinity, HPA, PDB, read-only root filesystems, non-root user capabilities drops, liveness/readiness probes, and configurations via ConfigMaps and Secret Manager.