### PR TITLE
ci: validate KCC path for basic-gke-hello-world

### DIFF
--- a/templates/basic-gke-hello-world/config-connector/cluster.yaml
+++ b/templates/basic-gke-hello-world/config-connector/cluster.yaml
@@ -36,3 +36,4 @@ spec:
   securityPostureConfig:
     mode: BASIC
     vulnerabilityMode: VULNERABILITY_BASIC
+# KCC validation trigger


### PR DESCRIPTION
## Summary

Triggers CI to validate the Config Connector deployment path for the `basic-gke-hello-world` template.

- The TF+Helm path was previously skipped; KCC showed success but re-confirming after recent changes (removed hardcoded `project_id` default, added `TF_VAR_project_id` injection to workflow)
- This PR is KCC-focused — the template uses Autopilot which has no GPU node pool concerns

## What CI will do

1. Lint check
2. Deploy KCC manifests to `forge-management` namespace on `krmapihost-kcc-instance`
3. Wait for all resources to become `Ready`
4. Delete KCC resources and verify cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)