### PR TITLE
ci: validate KCC path for enterprise-gke

### DIFF
--- a/templates/enterprise-gke/config-connector/cluster.yaml
+++ b/templates/enterprise-gke/config-connector/cluster.yaml
@@ -58,3 +58,4 @@ spec:
     vulnerabilityMode: VULNERABILITY_ENTERPRISE
   releaseChannel:
     channel: REGULAR
+# KCC validation trigger


### PR DESCRIPTION
## Summary

Triggers CI to validate the Config Connector deployment path for the `enterprise-gke` template.

- KCC path has not been validated for this template yet (Validation Record is incomplete)
- Confirms `ContainerCluster`, `ContainerNodePool`, `ComputeNetwork`, `ComputeSubnetwork`, `IAMServiceAccount`, `IAMPolicyMember`, `ComputeRouter`, `ComputeRouterNAT` all reconcile correctly via KCC
- Also verifies the Nginx workload manifests deploy successfully to the provisioned cluster

## What CI will do

1. Lint + KCC manifest syntax checks
2. Deploy KCC manifests to `forge-management` namespace on `krmapihost-kcc-instance`
3. Wait for all resources to become `Ready`
4. Deploy workload manifests to the KCC-managed cluster
5. Delete KCC resources and verify cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)