### PR TITLE
Template: Zero-Trust AI Egress via FQDN Network Policies

### DIFF
--- a/.github/workflows/cleanup-orphans.yml
+++ b/.github/workflows/cleanup-orphans.yml
@@ -182,7 +182,7 @@ jobs:
           echo "Cleaning up orphaned Networking resources (matching pattern)..."
           
           # Firewalls (Generic exclusion)
-          FIREWALLS=$(gcloud compute firewall-rules list --project=$PROJECT --format="value(name)" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete|default" || true)
+          FIREWALLS=$(gcloud compute firewall-rules list --project=$PROJECT --format="value(name)" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete|default|^k8s-fw-" || true)
           for F in $FIREWALLS; do
             SKIP=false
             for PAT in $ALL_ACTIVE; do

--- a/.github/workflows/cleanup-orphans.yml
+++ b/.github/workflows/cleanup-orphans.yml
@@ -97,7 +97,7 @@ jobs:
           gcloud container clusters get-credentials krmapihost-kcc-instance --region $REGION --project $PROJECT
           
           echo "Deleting all KCC-managed resources with project=gcp-template-forge label..."
-          KCC_TYPES="containercluster,computenetwork,computesubnetwork,computerouter,computerouternat,computefirewall"
+          KCC_TYPES="containercluster,containernodepool,computenetwork,computesubnetwork,computerouter,computerouternat,computefirewall"
           KCC_RESOURCES=$(kubectl get $KCC_TYPES -n forge-management -l project=gcp-template-forge -o name | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
           
           for RES in $KCC_RESOURCES; do

--- a/.github/workflows/cleanup-orphans.yml
+++ b/.github/workflows/cleanup-orphans.yml
@@ -150,7 +150,7 @@ jobs:
             [ -z "$NEG_NAME" ] && continue
             
             # Check if the network matches our pattern
-            if [[ "$NEG_NET" =~ "latest-gke-features-" || "$NEG_NET" =~ "enterprise-gke-" || "$NEG_NET" =~ "basic-gke-|gke-fqdn-egress-security-" ]]; then
+            if [[ "$NEG_NET" =~ latest-gke-features- || "$NEG_NET" =~ enterprise-gke- || "$NEG_NET" =~ (basic-gke-|gke-fqdn-egress-security-) ]]; then
               # Check safe-list
               if [[ "$NEG_NET" =~ "repo-agent-standard" || "$NEG_NET" =~ "krmapihost-kcc-instance" || "$NEG_NET" =~ "kcc-dash-dont-delete" ]]; then
                 continue

--- a/.github/workflows/cleanup-orphans.yml
+++ b/.github/workflows/cleanup-orphans.yml
@@ -115,7 +115,7 @@ jobs:
           echo "Searching for orphaned Terraform clusters..."
           TF_CLUSTERS=$(gcloud container clusters list \
             --project=$PROJECT \
-            --filter="resourceLabels.project=gcp-template-forge OR name ~ latest-gke-features- OR name ~ enterprise-gke- OR name ~ basic-gke-" \
+            --filter="resourceLabels.project=gcp-template-forge OR name ~ latest-gke-features- OR name ~ enterprise-gke- OR name ~ basic-gke- OR name ~ gke-fqdn-egress-security-" \
             --format="value(name, zone.scope())")
 
           while read -r CLUSTER C_LOC; do
@@ -150,7 +150,7 @@ jobs:
             [ -z "$NEG_NAME" ] && continue
             
             # Check if the network matches our pattern
-            if [[ "$NEG_NET" =~ "latest-gke-features-" || "$NEG_NET" =~ "enterprise-gke-" || "$NEG_NET" =~ "basic-gke-" ]]; then
+            if [[ "$NEG_NET" =~ "latest-gke-features-" || "$NEG_NET" =~ "enterprise-gke-" || "$NEG_NET" =~ "basic-gke-|gke-fqdn-egress-security-" ]]; then
               # Check safe-list
               if [[ "$NEG_NET" =~ "repo-agent-standard" || "$NEG_NET" =~ "krmapihost-kcc-instance" || "$NEG_NET" =~ "kcc-dash-dont-delete" ]]; then
                 continue
@@ -181,7 +181,7 @@ jobs:
           echo "Cleaning up orphaned Networking resources (matching pattern)..."
           
           # Firewalls (BROADER PATTERN to catch gke- prefix)
-          FIREWALLS=$(gcloud compute firewall-rules list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+          FIREWALLS=$(gcloud compute firewall-rules list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
           for F in $FIREWALLS; do
             SKIP=false
             for PAT in $ALL_ACTIVE; do
@@ -202,7 +202,7 @@ jobs:
           ALL_ROUTERS=$(gcloud compute routers list --project=$PROJECT --format="value(name, region)")
           
           for RGN in $REGIONS; do
-            ROUTERS=$(echo "$ALL_ROUTERS" | grep "$RGN" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" | awk '{print $1}' || true)
+            ROUTERS=$(echo "$ALL_ROUTERS" | grep "$RGN" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" | awk '{print $1}' || true)
             for R in $ROUTERS; do
               SKIP=false
               for PAT in $ALL_ACTIVE; do
@@ -230,7 +230,7 @@ jobs:
           ALL_SUBNETS=$(gcloud compute networks subnets list --project=$PROJECT --format="value(name, region)")
           
           for RGN in $REGIONS; do
-            SUBNETS=$(echo "$ALL_SUBNETS" | grep "$RGN" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" | awk '{print $1}' || true)
+            SUBNETS=$(echo "$ALL_SUBNETS" | grep "$RGN" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" | awk '{print $1}' || true)
             for S in $SUBNETS; do
               SKIP=false
               for PAT in $ALL_ACTIVE; do
@@ -250,7 +250,7 @@ jobs:
           echo "Listing all networks in project..."
           gcloud compute networks list --project=$PROJECT
 
-          NETWORKS=$(gcloud compute networks list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+          NETWORKS=$(gcloud compute networks list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
           for N in $NETWORKS; do
             SKIP=false
             for PAT in $ALL_ACTIVE; do

--- a/.github/workflows/sandbox-validation.yml
+++ b/.github/workflows/sandbox-validation.yml
@@ -379,6 +379,11 @@ jobs:
       - name: Terraform destroy
         working-directory: ${{ matrix.template }}/terraform-helm
         run: |
+          RUN_ID="${{ github.run_id }}"
+          UID_SUFFIX="${RUN_ID: -6}"
+          export TF_VAR_cluster_name="$(basename ${{ matrix.template }})-${UID_SUFFIX}-tf"
+          export TF_VAR_network_name="$(basename ${{ matrix.template }})-${UID_SUFFIX}-tf-vpc"
+          export TF_VAR_subnet_name="$(basename ${{ matrix.template }})-${UID_SUFFIX}-tf-subnet"
           terraform init \
             -backend-config="bucket=$TF_STATE_BUCKET" \
             -backend-config="prefix=${{ matrix.template }}-${{ github.run_id }}/terraform-helm"
@@ -577,6 +582,9 @@ jobs:
 
       - name: Delete KCC resources
         run: |
+          RUN_ID="${{ github.run_id }}"
+          UID_SUFFIX="${RUN_ID: -6}"
+          find ${{ matrix.template }}/config-connector -type f -name "*.yaml" -exec sed -i "s/$(basename ${{ matrix.template }})/$(basename ${{ matrix.template }})-${UID_SUFFIX}/g" {} +
           kubectl delete \
             -n $KCC_NAMESPACE \
             -f ${{ matrix.template }}/config-connector/ \
@@ -670,6 +678,9 @@ jobs:
       - name: KCC cleanup (delete if any resources exist)
         if: "hashFiles(format('{0}/config-connector/**', matrix.template)) != ''"
         run: |
+          RUN_ID="${{ github.run_id }}"
+          UID_SUFFIX="${RUN_ID: -6}"
+          find ${{ matrix.template }}/config-connector -type f -name "*.yaml" -exec sed -i "s/$(basename ${{ matrix.template }})/$(basename ${{ matrix.template }})-${UID_SUFFIX}/g" {} +
           kubectl delete \
             -n ${{ env.KCC_NAMESPACE }} \
             -f ${{ matrix.template }}/config-connector/ \
@@ -934,6 +945,11 @@ jobs:
         if: always() && steps.tf-apply.outcome != 'skipped'
         working-directory: ${{ matrix.template }}/terraform-helm
         run: |
+          RUN_ID="${{ github.run_id }}"
+          UID_SUFFIX="${RUN_ID: -6}"
+          export TF_VAR_cluster_name="$(basename ${{ matrix.template }})-${UID_SUFFIX}-tf"
+          export TF_VAR_network_name="$(basename ${{ matrix.template }})-${UID_SUFFIX}-tf-vpc"
+          export TF_VAR_subnet_name="$(basename ${{ matrix.template }})-${UID_SUFFIX}-tf-subnet"
           terraform destroy -auto-approve -input=false || \
           terraform destroy -auto-approve -input=false
 

--- a/.github/workflows/sandbox-validation.yml
+++ b/.github/workflows/sandbox-validation.yml
@@ -492,12 +492,22 @@ jobs:
         run: |
           RUN_ID="${{ github.run_id }}"
           UID_SUFFIX="${RUN_ID: -6}"
-          CLUSTER_NAME=$(kubectl get containerclusters.container.cnrm.cloud.google.com -n $KCC_NAMESPACE -l template=$(basename ${{ matrix.template }})-${UID_SUFFIX} -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-          LOCATION=$(kubectl get containerclusters.container.cnrm.cloud.google.com -n $KCC_NAMESPACE -l template=$(basename ${{ matrix.template }})-${UID_SUFFIX} -o jsonpath='{.items[0].spec.location}' 2>/dev/null || true)
-          if [ -z "$CLUSTER_NAME" ]; then
-             CLUSTER_NAME=$(python3 -c "import yaml, pathlib; docs=[d for p in pathlib.Path('${{ matrix.template }}/config-connector').rglob('*.yaml') if p.is_file() for d in yaml.safe_load_all(p.read_text()) if d and d.get('kind')=='ContainerCluster']; print(docs[0]['metadata']['name'] if docs else '')")
-             LOCATION=$(python3 -c "import yaml, pathlib; docs=[d for p in pathlib.Path('${{ matrix.template }}/config-connector').rglob('*.yaml') if p.is_file() for d in yaml.safe_load_all(p.read_text()) if d and d.get('kind')=='ContainerCluster']; print(docs[0]['spec']['location'] if docs else '')")
+          
+          # Check if template intends to create a cluster
+          HAS_CLUSTER=$(python3 -c "import yaml, pathlib; docs=[d for p in pathlib.Path('${{ matrix.template }}/config-connector').rglob('*.yaml') if p.is_file() for d in yaml.safe_load_all(p.read_text()) if d and d.get('kind')=='ContainerCluster']; print('true' if docs else 'false')")
+          
+          if [ "$HAS_CLUSTER" = "true" ]; then
+            CLUSTER_NAME="$(basename ${{ matrix.template }})-${UID_SUFFIX}"
+            # Get location from management cluster if possible, or fallback to file
+            LOCATION=$(kubectl get containerclusters.container.cnrm.cloud.google.com -n $KCC_NAMESPACE -l template=$(basename ${{ matrix.template }})-${UID_SUFFIX} -o jsonpath='{.items[0].spec.location}' 2>/dev/null || true)
+            if [ -z "$LOCATION" ]; then
+               LOCATION=$(python3 -c "import yaml, pathlib; docs=[d for p in pathlib.Path('${{ matrix.template }}/config-connector').rglob('*.yaml') if p.is_file() for d in yaml.safe_load_all(p.read_text()) if d and d.get('kind')=='ContainerCluster']; print(docs[0]['spec']['location'] if docs else '')")
+            fi
+          else
+            CLUSTER_NAME=""
+            LOCATION=""
           fi
+          
           echo "cluster_name=${CLUSTER_NAME}" >> $GITHUB_OUTPUT
           echo "location=${LOCATION}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/sandbox-validation.yml
+++ b/.github/workflows/sandbox-validation.yml
@@ -294,7 +294,7 @@ jobs:
 
   tf-test:
     name: "Test TF (${{ matrix.template }})"
-    needs: [ tf-provision ]
+    needs: [ tf-provision, detect-changes ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -338,6 +338,8 @@ jobs:
 
           if [ -f "${{ matrix.template }}/validate.sh" ]; then
             echo "=== Running template-specific validation: ${{ matrix.template }}/validate.sh ==="
+            export CLUSTER_NAME="${{ needs.tf-provision.outputs.tf_cluster }}"
+            export REGION="${{ needs.tf-provision.outputs.tf_location }}"
             chmod +x ${{ matrix.template }}/validate.sh
             ./${{ matrix.template }}/validate.sh
           fi
@@ -354,7 +356,7 @@ jobs:
 
   tf-teardown:
     name: "Teardown TF (${{ matrix.template }})"
-    needs: [ tf-provision, tf-test ]
+    needs: [ tf-provision, tf-test, detect-changes ]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -464,7 +466,7 @@ jobs:
 
   kcc-test:
     name: "KCC Test (${{ matrix.template }})"
-    needs: [ kcc-apply ]
+    needs: [ kcc-apply, detect-changes ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -537,13 +539,14 @@ jobs:
           if [ -f "${{ matrix.template }}/validate.sh" ]; then
             echo "=== Running template-specific validation (KCC): ${{ matrix.template }}/validate.sh ==="
             export CLUSTER_NAME="${{ steps.kcc-workload-info.outputs.cluster_name }}"
+            export REGION="${{ steps.kcc-workload-info.outputs.location }}"
             chmod +x ${{ matrix.template }}/validate.sh
             ./${{ matrix.template }}/validate.sh
           fi
 
   kcc-teardown:
     name: "KCC Teardown (${{ matrix.template }})"
-    needs: [ kcc-apply, kcc-test ]
+    needs: [ kcc-apply, kcc-test, detect-changes ]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -821,9 +824,8 @@ jobs:
           # Run template-specific validation if present
           if [ -f "${{ matrix.template }}/validate.sh" ]; then
             echo "=== Running template-specific validation: ${{ matrix.template }}/validate.sh ==="
-            RUN_ID="${{ github.run_id }}"
-            UID_SUFFIX="${RUN_ID: -6}"
-            export CLUSTER_NAME="$(basename ${{ matrix.template }})-${UID_SUFFIX}-tf"
+            export CLUSTER_NAME="${{ steps.tf-outputs.outputs.tf_cluster }}"
+            export REGION="${{ steps.tf-outputs.outputs.tf_location }}"
             chmod +x ${{ matrix.template }}/validate.sh
             ./${{ matrix.template }}/validate.sh
           fi
@@ -1132,6 +1134,7 @@ jobs:
           if [ -f "${{ matrix.template }}/validate.sh" ]; then
             echo "=== Running template-specific validation (KCC): ${{ matrix.template }}/validate.sh ==="
             export CLUSTER_NAME="${{ steps.kcc-workload-info.outputs.cluster_name }}"
+            export REGION="${{ steps.kcc-workload-info.outputs.location }}"
             chmod +x ${{ matrix.template }}/validate.sh
             ./${{ matrix.template }}/validate.sh
           fi

--- a/.github/workflows/sandbox-validation.yml
+++ b/.github/workflows/sandbox-validation.yml
@@ -499,9 +499,14 @@ jobs:
           HAS_CLUSTER=$(python3 -c "import yaml, pathlib; docs=[d for p in pathlib.Path('${{ matrix.template }}/config-connector').rglob('*.yaml') if p.is_file() for d in yaml.safe_load_all(p.read_text()) if d and d.get('kind')=='ContainerCluster']; print('true' if docs else 'false')")
           
           if [ "$HAS_CLUSTER" = "true" ]; then
-            CLUSTER_NAME="$(basename ${{ matrix.template }})-${UID_SUFFIX}"
-            # Get location from management cluster if possible, or fallback to file
+            # Try to get cluster name and location from the management cluster using the unique label
+            CLUSTER_NAME=$(kubectl get containerclusters.container.cnrm.cloud.google.com -n $KCC_NAMESPACE -l template=$(basename ${{ matrix.template }})-${UID_SUFFIX} -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
             LOCATION=$(kubectl get containerclusters.container.cnrm.cloud.google.com -n $KCC_NAMESPACE -l template=$(basename ${{ matrix.template }})-${UID_SUFFIX} -o jsonpath='{.items[0].spec.location}' 2>/dev/null || true)
+            
+            # Fallback to local manifest parsing if not found in management cluster
+            if [ -z "$CLUSTER_NAME" ]; then
+               CLUSTER_NAME=$(python3 -c "import yaml, pathlib; docs=[d for p in pathlib.Path('${{ matrix.template }}/config-connector').rglob('*.yaml') if p.is_file() for d in yaml.safe_load_all(p.read_text()) if d and d.get('kind')=='ContainerCluster']; print(docs[0]['metadata']['name'] if docs else '')")
+            fi
             if [ -z "$LOCATION" ]; then
                LOCATION=$(python3 -c "import yaml, pathlib; docs=[d for p in pathlib.Path('${{ matrix.template }}/config-connector').rglob('*.yaml') if p.is_file() for d in yaml.safe_load_all(p.read_text()) if d and d.get('kind')=='ContainerCluster']; print(docs[0]['spec']['location'] if docs else '')")
             fi

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ templates/<name>/
 | [basic-gke-hello-world](templates/basic-gke-hello-world/) | GKE Autopilot + hello-world | GKE Autopilot | — |
 | [enterprise-gke](templates/enterprise-gke/) | GKE Standard + security stack + Helm workload | GKE Standard + networking | — |
 | [latest-gke-features](templates/latest-gke-features/) | GKE Standard + Gateway API + NAP + Native Sidecars | GKE Standard + KCC networking | — |
+| [gke-fqdn-egress-security](templates/gke-fqdn-egress-security/) | GKE Standard + FQDN Network Policies + AI Egress | GKE Standard + KCC Networking | — |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ templates/<name>/
 
 | Template | TF+Helm | KCC | Validated |
 |---|---|---|---|
-| [basic-gke-hello-world](templates/basic-gke-hello-world/) | GKE Autopilot + hello-world | GKE Autopilot | — |
-| [enterprise-gke](templates/enterprise-gke/) | GKE Standard + security stack + Helm workload | GKE Standard + networking | — |
-| [latest-gke-features](templates/latest-gke-features/) | GKE Standard + Gateway API + NAP + Native Sidecars | GKE Standard + KCC networking | — |
+| [basic-gke-hello-world](templates/basic-gke-hello-world/) | GKE Standard + hello-world | GKE Standard + hello-world | — |
+| [enterprise-gke](templates/enterprise-gke/) | GKE Standard + security stack + Helm workload | GKE Standard + security stack + KCC workload | — |
+| [latest-gke-features](templates/latest-gke-features/) | GKE Standard + Gateway API + NAP + Native Sidecars | GKE Standard + Native Sidecars + Gateway API | — |
 | [gke-fqdn-egress-security](templates/gke-fqdn-egress-security/) | GKE Standard + FQDN Network Policies + AI Egress | GKE Standard + KCC Networking | — |
-| [gke-topology-aware-routing](templates/gke-topology-aware-routing/) | GKE Standard + Topology-Aware Routing + Gateway API | GKE Standard + Topology Routing | — |
+| [gke-topology-aware-routing](templates/gke-topology-aware-routing/) | GKE Standard + Topology-Aware Routing + Gateway API | GKE Standard + Topology-Aware Routing + Gateway API | — |
 
 ---
 

--- a/agent-infra/cleanup-resources.sh
+++ b/agent-infra/cleanup-resources.sh
@@ -49,7 +49,7 @@ gcloud container clusters get-credentials $KCC_CLUSTER --region $REGION --projec
 if kubectl cluster-info &>/dev/null; then
   echo "Deleting all KCC-managed resources for orphaned environments..."
   KCC_TYPES="containercluster,computenetwork,computevpc,computesubnetwork,computerouter,computerouternat,computefirewall"
-  KCC_RESOURCES=$(kubectl get $KCC_TYPES -n $KCC_NAMESPACE -o name | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+  KCC_RESOURCES=$(kubectl get $KCC_TYPES -n $KCC_NAMESPACE -o name | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
   
   for RES in $KCC_RESOURCES; do
     SKIP=false
@@ -118,7 +118,7 @@ fi
 echo "Cleaning up orphaned Networking resources..."
 
 # Firewalls
-FIREWALLS=$(gcloud compute firewall-rules list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+FIREWALLS=$(gcloud compute firewall-rules list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
 for F in $FIREWALLS; do
   echo "Deleting firewall: $F"
   gcloud compute firewall-rules delete $F --project=$PROJECT --quiet || true
@@ -127,7 +127,7 @@ done
 # Routers and NATs across all regions
 REGIONS=$(gcloud compute regions list --project=$PROJECT --format="value(name)")
 for RGN in $REGIONS; do
-  ROUTERS=$(gcloud compute routers list --project=$PROJECT --regions=$RGN --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+  ROUTERS=$(gcloud compute routers list --project=$PROJECT --regions=$RGN --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
   for R in $ROUTERS; do
     echo "Checking NATs for router $R in $RGN"
     NATS=$(gcloud compute routers describe $R --project=$PROJECT --region=$RGN --format="value(nats.name)" | tr ';' ' ')
@@ -144,7 +144,7 @@ done
 
 echo "Waiting for routers to be fully deleted..."
 for i in {1..10}; do
-  STILL_THERE=$(gcloud compute routers list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" | wc -l)
+  STILL_THERE=$(gcloud compute routers list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" | wc -l)
   if [ "$STILL_THERE" -le 0 ]; then
     echo "All targeted routers deleted."
     break
@@ -155,13 +155,13 @@ done
 
 # VPN Resources
 for RGN in $REGIONS; do
-  TUNNELS=$(gcloud compute vpn-tunnels list --project=$PROJECT --regions=$RGN --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+  TUNNELS=$(gcloud compute vpn-tunnels list --project=$PROJECT --regions=$RGN --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
   for T in $TUNNELS; do
     echo "Deleting VPN tunnel: $T in $RGN"
     gcloud compute vpn-tunnels delete $T --region=$RGN --project=$PROJECT --quiet || true
   done
   
-  VPNS=$(gcloud compute vpn-gateways list --project=$PROJECT --regions=$RGN --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+  VPNS=$(gcloud compute vpn-gateways list --project=$PROJECT --regions=$RGN --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
   for V in $VPNS; do
     echo "Deleting VPN gateway: $V in $RGN"
     gcloud compute vpn-gateways delete $V --region=$RGN --project=$PROJECT --quiet || true
@@ -169,7 +169,7 @@ for RGN in $REGIONS; do
 done
 
 # L7 Resources
-FRULES=$(gcloud compute forwarding-rules list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+FRULES=$(gcloud compute forwarding-rules list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
 for FR in $FRULES; do
   echo "Deleting forwarding rule: $FR"
   gcloud compute forwarding-rules delete $FR --project=$PROJECT --global --quiet 2>/dev/null || \
@@ -178,7 +178,7 @@ done
 
 # Subnets
 for RGN in $REGIONS; do
-  SUBNETS=$(gcloud compute networks subnets list --project=$PROJECT --regions=$RGN --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+  SUBNETS=$(gcloud compute networks subnets list --project=$PROJECT --regions=$RGN --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
   for S in $SUBNETS; do
     echo "Deleting subnet $S in $RGN"
     gcloud compute networks subnets delete $S --region=$RGN --project=$PROJECT --quiet || true
@@ -186,7 +186,7 @@ for RGN in $REGIONS; do
 done
 
 # Networks (VPCs)
-NETWORKS=$(gcloud compute networks list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+NETWORKS=$(gcloud compute networks list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
 for N in $NETWORKS; do
   echo "Initiating deletion of network $N..."
   gcloud compute networks delete $N --project=$PROJECT --quiet || true
@@ -194,7 +194,7 @@ done
 
 echo "Waiting for networks to be fully deleted..."
 for i in {1..15}; do
-  STILL_THERE=$(gcloud compute networks list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" | wc -l)
+  STILL_THERE=$(gcloud compute networks list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" | wc -l)
   if [ "$STILL_THERE" -le 0 ]; then
     echo "All targeted networks deleted."
     break

--- a/agent-infra/cleanup-resources.sh
+++ b/agent-infra/cleanup-resources.sh
@@ -209,12 +209,17 @@ gcloud compute project-info describe --project=$PROJECT --format="json" > /tmp/q
 
 echo "Quota Comparison (Before vs After):"
 python3 << 'EOF' || true
-import sys, json
+import sys, json, os
 try:
+    if not os.path.exists('/tmp/quota_before.json') or os.path.getsize('/tmp/quota_before.json') == 0:
+        raise ValueError('quota_before.json is missing or empty')
+    if not os.path.exists('/tmp/quota_after.json') or os.path.getsize('/tmp/quota_after.json') == 0:
+        raise ValueError('quota_after.json is missing or empty')
+    
     before = json.load(open('/tmp/quota_before.json'))
     after = json.load(open('/tmp/quota_after.json'))
 except Exception as e:
-    print(f'Error loading quota files: {e}')
+    print(f'Note: Could not compare quotas (this is normal if gcloud failed): {e}')
     sys.exit(0)
 
 before_quotas = {q['metric']: q for q in before.get('quotas', [])}

--- a/agent-infra/cleanup-resources.sh
+++ b/agent-infra/cleanup-resources.sh
@@ -48,9 +48,12 @@ gcloud container clusters get-credentials $KCC_CLUSTER --region $REGION --projec
 
 if kubectl cluster-info &>/dev/null; then
   echo "Deleting all KCC-managed resources for orphaned environments..."
-  KCC_TYPES="containercluster,computenetwork,computevpc,computesubnetwork,computerouter,computerouternat,computefirewall"
-  KCC_RESOURCES=$(kubectl get $KCC_TYPES -n $KCC_NAMESPACE -o name | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-|gke-topology-aware-routing-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
-  
+  KCC_TYPES="containercluster,containernodepool,computenetwork,computesubnetwork,computerouter,computerouternat,computefirewall"
+  # Use the project label for more reliable detection, falling back to name patterns
+  KCC_RESOURCES=$(kubectl get $KCC_TYPES -n $KCC_NAMESPACE -l project=gcp-template-forge -o name 2>/dev/null | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+  if [ -z "$KCC_RESOURCES" ]; then
+    KCC_RESOURCES=$(kubectl get $KCC_TYPES -n $KCC_NAMESPACE -o name 2>/dev/null | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-|gke-llm-inference-|gke-vllm-staging-|gke-basic-|latest-features-|gke-fqdn-egress-security-|gke-topology-aware-routing-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+  fi
   for RES in $KCC_RESOURCES; do
     SKIP=false
     for RUN_ID in $ALL_ACTIVE; do

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -8,6 +8,8 @@ This template demonstrates how to implement a "Default Deny" egress policy in GK
 - **Zero-Trust Security:** Default deny all egress to prevent data exfiltration.
 - **AI-Focused:** Pre-configured for Anthropic and HuggingFace APIs.
 
+> **Note:** FQDN Network Policies require GKE Dataplane V2 and GKE Enterprise (Advanced Networking) to be enabled on the cluster. This template handles these requirements automatically in the manifests.
+
 ## Architecture
 1.  **GKE Cluster:** Configured with Dataplane V2 and GKE Enterprise Advanced Networking.
 2.  **Network Policies:**

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -1,38 +1,104 @@
 # GKE Zero-Trust AI Egress with FQDN Network Policies
 
-This template demonstrates how to implement a "Default Deny" egress policy in GKE and selectively allow traffic to specific external AI services using Fully Qualified Domain Name (FQDN) Network Policies.
-
-## Features
-- **Dataplane V2:** High-performance eBPF-based networking.
-- **FQDN Network Policies:** Allow egress to specific domains without managing static IP lists.
-- **Zero-Trust Security:** Default deny all egress to prevent data exfiltration.
-- **AI-Focused:** Pre-configured for Anthropic and HuggingFace APIs.
-
-> **Note:** FQDN Network Policies require GKE Dataplane V2 and GKE Enterprise (Advanced Networking) to be enabled on the cluster. This template handles these requirements automatically in the manifests.
+This template demonstrates how to implement a "Default Deny" egress policy in GKE and selectively allow traffic to specific external AI services (Anthropic, HuggingFace) using Fully Qualified Domain Name (FQDN) Network Policies.
 
 ## Architecture
-1.  **GKE Cluster:** Configured with Dataplane V2 and GKE Enterprise Advanced Networking.
+
+The template provisions a secure GKE environment with the following components:
+
+1.  **GKE Cluster (Standard):**
+    *   **Dataplane V2:** High-performance eBPF-based networking required for FQDN policies.
+    *   **GKE Enterprise Advanced Networking:** Required to enable the `FQDNNetworkPolicy` resource.
+    *   **Private Cluster:** Nodes have only private IP addresses for enhanced security.
+    *   **Cloud NAT:** Enables outbound internet access for private nodes.
 2.  **Network Policies:**
-    -   `default-deny-egress`: Denies all egress traffic by default.
-    -   `allow-ai-egress`: Selectively allows HTTPS traffic to `api.anthropic.com` and `huggingface.co`.
-3.  **Validation Pod:** A simple container used to verify that allowed domains are accessible while others (like `google.com`) are blocked.
+    *   `default-deny-egress`: A standard Kubernetes `NetworkPolicy` that blocks all outbound traffic from the namespace except for DNS (UDP/TCP port 53) to allow domain resolution.
+    *   `allow-ai-egress`: A GKE-specific `FQDNNetworkPolicy` that allow HTTPS (port 443) traffic to specific domains and their subdomains (e.g., `*.anthropic.com`, `*.huggingface.co`).
+3.  **Workload:**
+    *   `egress-verifier`: A Pod running a `curl` image used to verify the connectivity rules.
 
-## Usage
+## Prerequisites
 
-### Terraform & Helm
+*   A Google Cloud Project with billing enabled.
+*   The `gcloud` CLI installed and authenticated.
+*   `kubectl` and `terraform` (>= 1.7) installed.
+*   **GKE Enterprise:** The project must have the GKE Enterprise API enabled, as FQDN Network Policies are an Enterprise feature.
+
+## Deployment
+
+### Option 1: Terraform & Helm (Recommended)
+
+This path uses Terraform to provision the infrastructure and a local Helm chart for the workload.
+
+1.  Initialize and apply the infrastructure:
+    ```bash
+    cd terraform-helm
+    terraform init
+    terraform apply
+    ```
+    *Terraform will output the cluster name and location, and automatically generate a `values.yaml` for the Helm chart.*
+
+2.  The CI/CD pipeline or a manual Helm command can then deploy the workload. Manual command:
+    ```bash
+    gcloud container clusters get-credentials $(terraform output -raw cluster_name) --region $(terraform output -raw cluster_location)
+    helm upgrade --install egress-security ./workload -f workload/values.yaml
+    ```
+
+### Option 2: Config Connector (KCC)
+
+This path uses Kubernetes-native resource management via Google Cloud Config Connector.
+
+1.  Ensure Config Connector is installed in your management cluster and configured for your project.
+2.  Apply the manifests:
+    ```bash
+    kubectl apply -f config-connector/
+    kubectl apply -f config-connector/workload/
+    ```
+3.  Wait for the cluster to be ready:
+    ```bash
+    kubectl wait --for=condition=Ready containercluster gke-fqdn-egress-security-cluster -n forge-management --timeout=30m
+    ```
+
+## Verification
+
+### Automated Validation
+
+Run the provided validation script to perform automated connectivity tests:
+```bash
+./validate.sh
+```
+The script verifies:
+*   Dataplane V2 and FQDN Policy enablement.
+*   Successful egress to `api.anthropic.com`, `huggingface.co`, and `hf.co`.
+*   Blocked egress to `google.com`.
+
+### Manual Verification
+
+1.  Get credentials for the cluster.
+2.  Exec into the verifier pod:
+    ```bash
+    kubectl exec -it egress-verifier -- /bin/sh
+    ```
+3.  Test allowed egress:
+    ```bash
+    curl -I https://api.anthropic.com
+    curl -I https://huggingface.co
+    ```
+4.  Test blocked egress (should timeout):
+    ```bash
+    curl --connect-timeout 5 https://google.com
+    ```
+
+## Cleanup
+
+### Terraform
 ```bash
 cd terraform-helm
-terraform init
-terraform apply
+terraform destroy
 ```
 
 ### Config Connector
 ```bash
-kubectl apply -f config-connector/
-```
-
-## Verification
-The `validate.sh` script automates the verification of the egress policies.
-```bash
-./validate.sh
+kubectl delete -f config-connector/workload/
+kubectl delete -f config-connector/
 ```

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -1,0 +1,36 @@
+# GKE Zero-Trust AI Egress with FQDN Network Policies
+
+This template demonstrates how to implement a "Default Deny" egress policy in GKE and selectively allow traffic to specific external AI services using Fully Qualified Domain Name (FQDN) Network Policies.
+
+## Features
+- **Dataplane V2:** High-performance eBPF-based networking.
+- **FQDN Network Policies:** Allow egress to specific domains without managing static IP lists.
+- **Zero-Trust Security:** Default deny all egress to prevent data exfiltration.
+- **AI-Focused:** Pre-configured for Anthropic and HuggingFace APIs.
+
+## Architecture
+1.  **GKE Cluster:** Configured with Dataplane V2 and GKE Enterprise Advanced Networking.
+2.  **Network Policies:**
+    -   `default-deny-egress`: Denies all egress traffic by default.
+    -   `allow-ai-egress`: Selectively allows HTTPS traffic to `api.anthropic.com` and `huggingface.co`.
+3.  **Validation Pod:** A simple container used to verify that allowed domains are accessible while others (like `google.com`) are blocked.
+
+## Usage
+
+### Terraform & Helm
+```bash
+cd terraform-helm
+terraform init
+terraform apply
+```
+
+### Config Connector
+```bash
+kubectl apply -f config-connector/
+```
+
+## Verification
+The `validate.sh` script automates the verification of the egress policies.
+```bash
+./validate.sh
+```

--- a/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
@@ -44,14 +44,11 @@ spec:
     channel: REGULAR
   # Dataplane V2 is required for FQDN Network Policies
   datapathProvider: ADVANCED_DATAPATH
+  enableFqdnNetworkPolicy: true
   # Enable GKE Enterprise features (Vulnerability Enterprise is a good proxy for GKE Enterprise enablement)
   securityPostureConfig:
     mode: BASIC
     vulnerabilityMode: VULNERABILITY_ENTERPRISE
-  # Note: enableFqdnNetworkPolicy might not be available in all KCC versions
-  # but ADVANCED_DATAPATH is the primary requirement.
-  networkConfig:
-    enableFqdnNetworkPolicy: true
   loggingConfig:
     enableComponents:
       - SYSTEM_COMPONENTS

--- a/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
@@ -25,8 +25,6 @@ metadata:
     cnrm.cloud.google.com/remove-default-node-pool: "true"
 spec:
   location: us-central1
-  # MANDATORY for CI
-  deletionProtection: false
   initialNodeCount: 1
   networkingMode: VPC_NATIVE
   networkRef:

--- a/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
@@ -37,7 +37,7 @@ spec:
   privateClusterConfig:
     enablePrivateNodes: true
     enablePrivateEndpoint: false
-    masterIpv4CidrBlock: 172.16.0.32/28
+    masterIpv4CidrBlock: "172.16.0.32/28"
   workloadIdentityConfig:
     workloadPool: "gca-gke-2025.svc.id.goog"
   releaseChannel:

--- a/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: fqdn-egress-cluster
+  namespace: forge-management
+  labels:
+    project: gcp-template-forge
+    template: gke-fqdn-egress-security
+  annotations:
+    cnrm.cloud.google.com/project-id: gca-gke-2025
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+spec:
+  location: us-central1
+  initialNodeCount: 1
+  networkingMode: VPC_NATIVE
+  networkRef:
+    name: fqdn-egress-vpc
+  subnetworkRef:
+    name: fqdn-egress-subnet
+  ipAllocationPolicy:
+    clusterSecondaryRangeName: pods
+    servicesSecondaryRangeName: services
+  privateClusterConfig:
+    enablePrivateNodes: true
+    enablePrivateEndpoint: false
+    masterIpv4CidrBlock: 172.16.0.32/28
+  workloadIdentityConfig:
+    workloadPool: "gca-gke-2025.svc.id.goog"
+  releaseChannel:
+    channel: REGULAR
+  # Dataplane V2 is required for FQDN Network Policies
+  datapathProvider: ADVANCED_DATAPATH
+  # Enable GKE Enterprise features (Vulnerability Enterprise is a good proxy for GKE Enterprise enablement)
+  securityPostureConfig:
+    mode: BASIC
+    vulnerabilityMode: VULNERABILITY_ENTERPRISE
+  # Note: enableFqdnNetworkPolicy might not be available in all KCC versions
+  # but ADVANCED_DATAPATH is the primary requirement.
+  networkConfig:
+    enableFqdnNetworkPolicy: true
+  loggingConfig:
+    enableComponents:
+      - SYSTEM_COMPONENTS
+      - WORKLOADS
+  monitoringConfig:
+    enableComponents:
+      - SYSTEM_COMPONENTS
+    managedPrometheus:
+      enabled: true

--- a/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
@@ -25,6 +25,8 @@ metadata:
     cnrm.cloud.google.com/remove-default-node-pool: "true"
 spec:
   location: us-central1
+  # MANDATORY for CI
+  deletionProtection: false
   initialNodeCount: 1
   networkingMode: VPC_NATIVE
   networkRef:

--- a/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
@@ -25,6 +25,7 @@ metadata:
     cnrm.cloud.google.com/remove-default-node-pool: "true"
 spec:
   location: us-central1
+  deletionProtection: false
   initialNodeCount: 1
   networkingMode: VPC_NATIVE
   networkRef:

--- a/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
@@ -45,9 +45,6 @@ spec:
   # Dataplane V2 is required for FQDN Network Policies
   datapathProvider: ADVANCED_DATAPATH
   enableFqdnNetworkPolicy: true
-  resourceLabels:
-    project: gcp-template-forge
-    template: gke-fqdn-egress-security
   # Enable GKE Enterprise features (Vulnerability Enterprise is a good proxy for GKE Enterprise enablement)
   securityPostureConfig:
     mode: BASIC

--- a/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
@@ -45,6 +45,9 @@ spec:
   # Dataplane V2 is required for FQDN Network Policies
   datapathProvider: ADVANCED_DATAPATH
   enableFqdnNetworkPolicy: true
+  resourceLabels:
+    project: gcp-template-forge
+    template: gke-fqdn-egress-security
   # Enable GKE Enterprise features (Vulnerability Enterprise is a good proxy for GKE Enterprise enablement)
   securityPostureConfig:
     mode: BASIC

--- a/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/cluster.yaml
@@ -15,7 +15,7 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerCluster
 metadata:
-  name: fqdn-egress-cluster
+  name: gke-fqdn-egress-security-cluster
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -28,9 +28,9 @@ spec:
   initialNodeCount: 1
   networkingMode: VPC_NATIVE
   networkRef:
-    name: fqdn-egress-vpc
+    name: gke-fqdn-egress-security-vpc
   subnetworkRef:
-    name: fqdn-egress-subnet
+    name: gke-fqdn-egress-security-subnet
   ipAllocationPolicy:
     clusterSecondaryRangeName: pods
     servicesSecondaryRangeName: services

--- a/templates/gke-fqdn-egress-security/config-connector/network.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/network.yaml
@@ -1,0 +1,76 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: fqdn-egress-vpc
+  namespace: forge-management
+  labels:
+    project: gcp-template-forge
+    template: gke-fqdn-egress-security
+spec:
+  routingMode: REGIONAL
+  autoCreateSubnetworks: false
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: fqdn-egress-subnet
+  namespace: forge-management
+  labels:
+    project: gcp-template-forge
+    template: gke-fqdn-egress-security
+spec:
+  location: us-central1
+  networkRef:
+    name: fqdn-egress-vpc
+  ipCidrRange: 10.0.0.0/20
+  secondaryIpRange:
+    - rangeName: pods
+      ipCidrRange: 10.4.0.0/14
+    - rangeName: services
+      ipCidrRange: 10.8.0.0/20
+  privateIpGoogleAccess: true
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeRouter
+metadata:
+  name: fqdn-egress-router
+  namespace: forge-management
+  labels:
+    project: gcp-template-forge
+    template: gke-fqdn-egress-security
+spec:
+  location: us-central1
+  networkRef:
+    name: fqdn-egress-vpc
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeRouterNAT
+metadata:
+  name: fqdn-egress-nat
+  namespace: forge-management
+  labels:
+    project: gcp-template-forge
+    template: gke-fqdn-egress-security
+spec:
+  location: us-central1
+  routerRef:
+    name: fqdn-egress-router
+  natIpAllocateOption: AUTO_ONLY
+  sourceSubnetworkIpRangesToNat: ALL_SUBNETWORKS_ALL_IP_RANGES
+  logConfig:
+    enable: true
+    filter: ERRORS_ONLY

--- a/templates/gke-fqdn-egress-security/config-connector/network.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/network.yaml
@@ -15,7 +15,7 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:
-  name: fqdn-egress-vpc
+  name: gke-fqdn-egress-security-vpc
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -29,7 +29,7 @@ spec:
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSubnetwork
 metadata:
-  name: fqdn-egress-subnet
+  name: gke-fqdn-egress-security-subnet
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -39,7 +39,7 @@ metadata:
 spec:
   region: us-central1
   networkRef:
-    name: fqdn-egress-vpc
+    name: gke-fqdn-egress-security-vpc
   ipCidrRange: 10.0.0.0/20
   secondaryIpRange:
     - rangeName: pods
@@ -51,7 +51,7 @@ spec:
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeRouter
 metadata:
-  name: fqdn-egress-router
+  name: gke-fqdn-egress-security-router
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -61,12 +61,12 @@ metadata:
 spec:
   region: us-central1
   networkRef:
-    name: fqdn-egress-vpc
+    name: gke-fqdn-egress-security-vpc
 ---
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeRouterNAT
 metadata:
-  name: fqdn-egress-nat
+  name: gke-fqdn-egress-security-nat
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -76,7 +76,7 @@ metadata:
 spec:
   region: us-central1
   routerRef:
-    name: fqdn-egress-router
+    name: gke-fqdn-egress-security-router
   natIpAllocateOption: AUTO_ONLY
   sourceSubnetworkIpRangesToNat: ALL_SUBNETWORKS_ALL_IP_RANGES
   logConfig:

--- a/templates/gke-fqdn-egress-security/config-connector/network.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/network.yaml
@@ -82,3 +82,26 @@ spec:
   logConfig:
     enable: true
     filter: ERRORS_ONLY
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeFirewall
+metadata:
+  name: gke-fqdn-egress-security-master-to-node
+  namespace: forge-management
+  annotations:
+    cnrm.cloud.google.com/project-id: gca-gke-2025
+  labels:
+    project: gcp-template-forge
+    template: gke-fqdn-egress-security
+spec:
+  networkRef:
+    name: gke-fqdn-egress-security-vpc
+  sourceRanges:
+    - "172.16.0.32/28"
+  targetTags:
+    - "gke-fqdn-egress-security-node"
+  allow:
+    - protocol: tcp
+      ports:
+        - "443"
+        - "10250"

--- a/templates/gke-fqdn-egress-security/config-connector/network.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/network.yaml
@@ -20,6 +20,8 @@ metadata:
   labels:
     project: gcp-template-forge
     template: gke-fqdn-egress-security
+  annotations:
+    cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
   routingMode: REGIONAL
   autoCreateSubnetworks: false
@@ -32,8 +34,10 @@ metadata:
   labels:
     project: gcp-template-forge
     template: gke-fqdn-egress-security
+  annotations:
+    cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
-  location: us-central1
+  region: us-central1
   networkRef:
     name: fqdn-egress-vpc
   ipCidrRange: 10.0.0.0/20
@@ -52,8 +56,10 @@ metadata:
   labels:
     project: gcp-template-forge
     template: gke-fqdn-egress-security
+  annotations:
+    cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
-  location: us-central1
+  region: us-central1
   networkRef:
     name: fqdn-egress-vpc
 ---
@@ -65,8 +71,10 @@ metadata:
   labels:
     project: gcp-template-forge
     template: gke-fqdn-egress-security
+  annotations:
+    cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
-  location: us-central1
+  region: us-central1
   routerRef:
     name: fqdn-egress-router
   natIpAllocateOption: AUTO_ONLY

--- a/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerNodePool
+metadata:
+  name: fqdn-egress-pool
+  namespace: forge-management
+  labels:
+    project: gcp-template-forge
+    template: gke-fqdn-egress-security
+spec:
+  clusterRef:
+    name: fqdn-egress-cluster
+  location: us-central1
+  nodeCount: 1
+  nodeConfig:
+    machineType: e2-standard-4
+    diskSizeGb: 50
+    oauthScopes:
+      - https://www.googleapis.com/auth/cloud-platform
+    serviceAccountRef:
+      external: forge-kcc-admin@gca-gke-2025.iam.gserviceaccount.com
+    shieldedInstanceConfig:
+      enableSecureBoot: true
+      enableIntegrityMonitoring: true
+    workloadMetadataConfig:
+      mode: GKE_METADATA

--- a/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
@@ -38,6 +38,9 @@ spec:
     shieldedInstanceConfig:
       enableSecureBoot: true
       enableIntegrityMonitoring: true
+    tags:
+      - "gke-node"
+      - "gke-fqdn-egress-security-node"
     workloadMetadataConfig:
       mode: GKE_METADATA
     labels:

--- a/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
@@ -34,7 +34,7 @@ spec:
     oauthScopes:
       - https://www.googleapis.com/auth/cloud-platform
     serviceAccountRef:
-      external: forge-kcc-admin@gca-gke-2025.iam.gserviceaccount.com
+      external: forge-builder@gca-gke-2025.iam.gserviceaccount.com
     shieldedInstanceConfig:
       enableSecureBoot: true
       enableIntegrityMonitoring: true

--- a/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
@@ -43,3 +43,6 @@ spec:
     labels:
       project: gcp-template-forge
       template: gke-fqdn-egress-security
+    resourceLabels:
+      project: gcp-template-forge
+      template: gke-fqdn-egress-security

--- a/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
@@ -37,3 +37,6 @@ spec:
       enableIntegrityMonitoring: true
     workloadMetadataConfig:
       mode: GKE_METADATA
+    labels:
+      project: gcp-template-forge
+      template: gke-fqdn-egress-security

--- a/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
@@ -15,7 +15,7 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
 metadata:
-  name: fqdn-egress-pool
+  name: gke-fqdn-egress-security-pool
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -24,7 +24,7 @@ metadata:
     cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
   clusterRef:
-    name: fqdn-egress-cluster
+    name: gke-fqdn-egress-security-cluster
   location: us-central1
   nodeCount: 1
   nodeConfig:

--- a/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
@@ -43,6 +43,3 @@ spec:
     labels:
       project: gcp-template-forge
       template: gke-fqdn-egress-security
-    resourceLabels:
-      project: gcp-template-forge
-      template: gke-fqdn-egress-security

--- a/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
@@ -20,6 +20,8 @@ metadata:
   labels:
     project: gcp-template-forge
     template: gke-fqdn-egress-security
+  annotations:
+    cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
   clusterRef:
     name: fqdn-egress-cluster

--- a/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/nodepool.yaml
@@ -28,6 +28,7 @@ spec:
   location: us-central1
   nodeCount: 1
   nodeConfig:
+    spot: true
     machineType: e2-standard-4
     diskSizeGb: 50
     oauthScopes:

--- a/templates/gke-fqdn-egress-security/config-connector/workload/egress-verifier.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/workload/egress-verifier.yaml
@@ -1,0 +1,26 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: egress-verifier
+  labels:
+    app: egress-test
+spec:
+  containers:
+  - name: verifier
+    image: curlimages/curl:8.4.0
+    command: ["/bin/sh", "-c", "sleep 3600"]
+  restartPolicy: Never

--- a/templates/gke-fqdn-egress-security/config-connector/workload/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/workload/fqdn-network-policy.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.gke.io/v1alpha1
+kind: FQDNNetworkPolicy
+metadata:
+  name: allow-ai-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: egress-test
+  egress:
+  - matches:
+    - name: anthropic.com
+    - name: api.anthropic.com
+    - pattern: "*.anthropic.com"
+    - name: huggingface.co
+    - pattern: "*.huggingface.co"
+    - name: hf.co
+    - pattern: "*.hf.co"
+    ports:
+    - protocol: TCP
+      port: 443

--- a/templates/gke-fqdn-egress-security/config-connector/workload/network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector/workload/network-policy.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  # Allow DNS resolution for all pods to enable FQDN resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53

--- a/templates/gke-fqdn-egress-security/terraform-helm/.terraform.lock.hcl
+++ b/templates/gke-fqdn-egress-security/terraform-helm/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:faTJQOetP9/RYuHwA3r2SWnuYoyzQNm4tUWZrZggcgY=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:uxh4ME3hhSzVjmiWgA1IQqYqg25MV6FMVArHyA6Ki5o=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.8.0"
+  hashes = [
+    "h1:KCuj8nPbNP/ofQrAoQIuQ3CP6k+ADpULvxr7dw2PrpM=",
+    "zh:05f18164beab4a84753e5fedf463771ee0c6eca8e90346b8766f1e1c186dec1e",
+    "zh:563a0702e3711e25ba8930120899b681378b50cbb957fd204b37745c7c9b5f40",
+    "zh:5b56ab2ed70ed92721febb4a070af0837f1084c44825c18e4b95f7efb1d45d26",
+    "zh:6cbedc09b67a5cdb9501ff1b18a315fa46a38e0530424cab1c7f4b3acc75f489",
+    "zh:71b3bd50f89fb385a42a436ba2ce2b8e00f9de53535ce956deff1477b0b117dc",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9d45ac0a00b85cabdd398b859349d17f124c598b6e6bf272f1bb01321ce708a8",
+    "zh:a453efe8641a8f31fe806b597bf2b34d7b78b971a8e3919061ea89d61fda7b8d",
+    "zh:ac692bacb8c3dca8b5b37e5383168aca1f87d3cd7b40615efd300defb76494f5",
+    "zh:bda9e90c8547d90c9c573206985c5675cc1406047605af037a5069942c3c5966",
+    "zh:c30a1967de040d00f5038086dd53cdbfb78cc05d1dbc75037410f011bf2a20d8",
+    "zh:c80bbd1c3f56b3c836d80cf93ac0e8809305c2642f0c98b54bf5d05d3b12718c",
+  ]
+}

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -170,6 +170,8 @@ resource "google_container_node_pool" "primary_nodes" {
       enable_integrity_monitoring = true
     }
 
+    tags = ["gke-node", "${var.cluster_name}-node"]
+
     labels = {
       project  = "gcp-template-forge"
       template = "gke-fqdn-egress-security"
@@ -210,3 +212,21 @@ ${yamlencode({
 EOF
 }
 
+
+# Explicit firewall rule to allow GKE master to reach nodes on 443 and 10250.
+# While GKE usually creates this automatically, in private clusters with custom VPCs
+# it sometimes helps to be explicit to ensure kubectl exec and other features work reliably.
+resource "google_compute_firewall" "allow_master_to_node" {
+  name    = "${var.cluster_name}-master-to-node"
+  network = google_compute_network.vpc.name
+  project = var.project_id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443", "10250"]
+  }
+
+  # The master IPv4 CIDR block defined in the cluster
+  source_ranges = ["172.16.0.32/28"]
+  target_tags   = ["${var.cluster_name}-node"]
+}

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -117,6 +117,7 @@ resource "google_container_cluster" "cluster" {
 }
 
 resource "google_container_node_pool" "primary_nodes" {
+  provider   = google-beta
   name       = "fqdn-egress-pool"
   location   = var.region
   cluster    = google_container_cluster.cluster.name
@@ -143,18 +144,5 @@ resource "google_container_node_pool" "primary_nodes" {
       project  = "gcp-template-forge"
       template = "gke-fqdn-egress-security"
     }
-  }
-}
-
-# Helm Release for Workload
-resource "helm_release" "workload" {
-  name       = "fqdn-egress-security"
-  chart      = "${path.module}/workload"
-  namespace  = "default"
-  depends_on = [google_container_node_pool.primary_nodes]
-
-  set {
-    name  = "project_id"
-    value = var.project_id
   }
 }

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -133,6 +133,11 @@ resource "google_container_node_pool" "primary_nodes" {
       mode = "GKE_METADATA"
     }
 
+    shielded_instance_config {
+      enable_secure_boot          = true
+      enable_integrity_monitoring = true
+    }
+
     labels = {
       project  = "gcp-template-forge"
       template = "gke-fqdn-egress-security"

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -28,29 +28,29 @@ resource "google_compute_network" "vpc" {
   auto_create_subnetworks = false
 
   # MANDATORY for project tracking
-  project                 = var.project_id
+  project = var.project_id
 }
 
 # Subnet
 resource "google_compute_subnetwork" "subnet" {
-  name                     = var.subnet_name
-  ip_cidr_range            = "10.0.0.0/20"
-  region                   = var.region
-  network                  = google_compute_network.vpc.id
+  name          = var.subnet_name
+  ip_cidr_range = "10.0.0.0/20"
+  region        = var.region
+  network       = google_compute_network.vpc.id
+
   private_ip_google_access = true
 
   secondary_ip_range {
     range_name    = "pods"
     ip_cidr_range = "10.4.0.0/14"
   }
-
   secondary_ip_range {
     range_name    = "services"
     ip_cidr_range = "10.8.0.0/20"
   }
 
   # MANDATORY for project tracking
-  project                  = var.project_id
+  project = var.project_id
 }
 
 # Cloud NAT
@@ -62,9 +62,10 @@ resource "google_compute_router" "router" {
 }
 
 resource "google_compute_router_nat" "nat" {
-  name                               = "${var.cluster_name}-nat"
-  router                             = google_compute_router.router.name
-  region                             = var.region
+  name   = "${var.cluster_name}-nat"
+  router = google_compute_router.router.name
+  region = var.region
+
   project                            = var.project_id
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
@@ -77,33 +78,32 @@ resource "google_compute_router_nat" "nat" {
 
 # GKE Cluster
 resource "google_container_cluster" "cluster" {
-  provider                   = google-beta
-  name                       = var.cluster_name
-  location                   = var.region
+  provider = google-beta
+  name     = var.cluster_name
+  location = var.region
 
   # MANDATORY for CI
-  deletion_protection        = false
+  deletion_protection = false
 
-  resource_labels            = {
+  resource_labels = {
     project  = "gcp-template-forge"
     template = "gke-fqdn-egress-security"
   }
 
-  network                    = google_compute_network.vpc.name
-  subnetwork                 = google_compute_subnetwork.subnet.name
+  network         = google_compute_network.vpc.name
+  subnetwork      = google_compute_subnetwork.subnet.name
+  networking_mode = "VPC_NATIVE"
 
-  networking_mode            = "VPC_NATIVE"
   ip_allocation_policy {
     cluster_secondary_range_name  = "pods"
     services_secondary_range_name = "services"
   }
 
-  remove_default_node_pool   = true
-  initial_node_count         = 1
+  remove_default_node_pool = true
+  initial_node_count       = 1
 
   # Dataplane V2 is required for FQDN Network Policies
   datapath_provider          = "ADVANCED_DATAPATH"
-
   enable_fqdn_network_policy = true
 
   private_cluster_config {
@@ -111,7 +111,6 @@ resource "google_container_cluster" "cluster" {
     enable_private_endpoint = false
     master_ipv4_cidr_block  = "172.16.0.32/28"
   }
-
   workload_identity_config {
     workload_pool = "${var.project_id}.svc.id.goog"
   }
@@ -145,16 +144,17 @@ resource "google_container_cluster" "cluster" {
 }
 
 resource "google_container_node_pool" "primary_nodes" {
-  provider   = google-beta
-  name       = "fqdn-egress-pool"
-  location   = var.region
-  cluster    = google_container_cluster.cluster.name
+  provider = google-beta
+  name     = "fqdn-egress-pool"
+  location = var.region
+  cluster  = google_container_cluster.cluster.name
+
   node_count = 1
 
   node_config {
-    spot            = true
-    machine_type    = "e2-standard-4"
-    disk_size_gb    = 50
+    spot         = true
+    machine_type = "e2-standard-4"
+    disk_size_gb = 50
 
     service_account = var.service_account
     oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
@@ -182,7 +182,7 @@ resource "google_container_node_pool" "primary_nodes" {
 
 # Generate values.yaml for the Helm chart
 resource "local_file" "helm_values" {
-  content  = <<EOF
+  content = <<EOF
 # Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -207,3 +207,4 @@ ${yamlencode({
 EOF
   filename = "${path.module}/workload/values.yaml"
 }
+

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -93,6 +93,12 @@ resource "google_container_cluster" "cluster" {
 
   enable_fqdn_network_policy = true
 
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = false
+    master_ipv4_cidr_block  = "172.16.0.32/28"
+  }
+
   workload_identity_config {
     workload_pool = "${var.project_id}.svc.id.goog"
   }

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -171,3 +171,15 @@ resource "google_container_node_pool" "primary_nodes" {
     }
   }
 }
+
+# Generate values.yaml for the Helm chart
+resource "local_file" "helm_values" {
+  content = yamlencode({
+    project_id = var.project_id
+    pod = {
+      image = "curlimages/curl:8.4.0"
+      label = "egress-test"
+    }
+  })
+  filename = "${path.module}/workload/values.yaml"
+}

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -60,6 +60,11 @@ resource "google_compute_router_nat" "nat" {
   region                             = var.region
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
 }
 
 # GKE Cluster
@@ -101,6 +106,17 @@ resource "google_container_cluster" "cluster" {
 
   workload_identity_config {
     workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  logging_config {
+    enable_components = ["SYSTEM_COMPONENTS", "WORKLOADS"]
+  }
+
+  monitoring_config {
+    enable_components = ["SYSTEM_COMPONENTS"]
+    managed_prometheus {
+      enabled = true
+    }
   }
 
   release_channel {

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -28,7 +28,7 @@ resource "google_compute_network" "vpc" {
   auto_create_subnetworks = false
 
   # MANDATORY for project tracking
-  project = var.project_id
+  project                 = var.project_id
 }
 
 # Subnet
@@ -50,7 +50,7 @@ resource "google_compute_subnetwork" "subnet" {
   }
 
   # MANDATORY for project tracking
-  project = var.project_id
+  project                  = var.project_id
 }
 
 # Cloud NAT
@@ -77,32 +77,32 @@ resource "google_compute_router_nat" "nat" {
 
 # GKE Cluster
 resource "google_container_cluster" "cluster" {
-  provider = google-beta
-  name     = var.cluster_name
-  location = var.region
+  provider                   = google-beta
+  name                       = var.cluster_name
+  location                   = var.region
 
   # MANDATORY for CI
-  deletion_protection = false
+  deletion_protection        = false
 
-  resource_labels = {
+  resource_labels            = {
     project  = "gcp-template-forge"
     template = "gke-fqdn-egress-security"
   }
 
-  network    = google_compute_network.vpc.name
-  subnetwork = google_compute_subnetwork.subnet.name
+  network                    = google_compute_network.vpc.name
+  subnetwork                 = google_compute_subnetwork.subnet.name
 
-  networking_mode = "VPC_NATIVE"
+  networking_mode            = "VPC_NATIVE"
   ip_allocation_policy {
     cluster_secondary_range_name  = "pods"
     services_secondary_range_name = "services"
   }
 
-  remove_default_node_pool = true
-  initial_node_count       = 1
+  remove_default_node_pool   = true
+  initial_node_count         = 1
 
   # Dataplane V2 is required for FQDN Network Policies
-  datapath_provider = "ADVANCED_DATAPATH"
+  datapath_provider          = "ADVANCED_DATAPATH"
 
   enable_fqdn_network_policy = true
 
@@ -152,9 +152,9 @@ resource "google_container_node_pool" "primary_nodes" {
   node_count = 1
 
   node_config {
-    spot         = true
-    machine_type = "e2-standard-4"
-    disk_size_gb = 50
+    spot            = true
+    machine_type    = "e2-standard-4"
+    disk_size_gb    = 50
 
     service_account = var.service_account
     oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
@@ -182,7 +182,7 @@ resource "google_container_node_pool" "primary_nodes" {
 
 # Generate values.yaml for the Helm chart
 resource "local_file" "helm_values" {
-  content = <<EOF
+  content  = <<EOF
 # Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -91,9 +91,7 @@ resource "google_container_cluster" "cluster" {
   # Dataplane V2 is required for FQDN Network Policies
   datapath_provider = "ADVANCED_DATAPATH"
 
-  network_config {
-    enable_fqdn_network_policy = true
-  }
+  enable_fqdn_network_policy = true
 
   workload_identity_config {
     workload_pool = "${var.project_id}.svc.id.goog"

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -81,6 +81,7 @@ resource "google_container_cluster" "cluster" {
   provider = google-beta
   name     = var.cluster_name
   location = var.region
+  project  = var.project_id
 
   # MANDATORY for CI
   deletion_protection = false
@@ -148,6 +149,7 @@ resource "google_container_node_pool" "primary_nodes" {
   name     = "fqdn-egress-pool"
   location = var.region
   cluster  = google_container_cluster.cluster.name
+  project  = var.project_id
 
   node_count = 1
 

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -55,14 +55,14 @@ resource "google_compute_subnetwork" "subnet" {
 
 # Cloud NAT
 resource "google_compute_router" "router" {
-  name    = "fqdn-egress-router"
+  name    = "${var.cluster_name}-router"
   region  = var.region
   network = google_compute_network.vpc.id
   project = var.project_id
 }
 
 resource "google_compute_router_nat" "nat" {
-  name                               = "fqdn-egress-nat"
+  name                               = "${var.cluster_name}-nat"
   router                             = google_compute_router.router.name
   region                             = var.region
   project                            = var.project_id

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -182,12 +182,28 @@ resource "google_container_node_pool" "primary_nodes" {
 
 # Generate values.yaml for the Helm chart
 resource "local_file" "helm_values" {
-  content = yamlencode({
-    project_id = var.project_id
-    pod = {
-      image = "curlimages/curl:8.4.0"
-      label = "egress-test"
-    }
-  })
+  content = <<EOF
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+${yamlencode({
+  project_id = var.project_id
+  pod = {
+    image = "curlimages/curl:8.4.0"
+    label = "egress-test"
+  }
+})}
+EOF
   filename = "${path.module}/workload/values.yaml"
 }

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -26,6 +26,9 @@ provider "google-beta" {
 resource "google_compute_network" "vpc" {
   name                    = var.network_name
   auto_create_subnetworks = false
+
+  # MANDATORY for project tracking
+  project = var.project_id
 }
 
 # Subnet
@@ -45,6 +48,9 @@ resource "google_compute_subnetwork" "subnet" {
     range_name    = "services"
     ip_cidr_range = "10.8.0.0/20"
   }
+
+  # MANDATORY for project tracking
+  project = var.project_id
 }
 
 # Cloud NAT
@@ -52,12 +58,14 @@ resource "google_compute_router" "router" {
   name    = "fqdn-egress-router"
   region  = var.region
   network = google_compute_network.vpc.id
+  project = var.project_id
 }
 
 resource "google_compute_router_nat" "nat" {
   name                               = "fqdn-egress-nat"
   router                             = google_compute_router.router.name
   region                             = var.region
+  project                            = var.project_id
   nat_ip_allocate_option             = "AUTO_ONLY"
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
 

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -186,27 +186,27 @@ resource "google_container_node_pool" "primary_nodes" {
 resource "local_file" "helm_values" {
   filename = "${path.module}/workload/values.yaml"
   content = <<-EOF
-    # Copyright 2026 Google LLC
-    #
-    # Licensed under the Apache License, Version 2.0 (the "License");
-    # you may not use this file except in compliance with the License.
-    # You may obtain a copy of the License at
-    #
-    #      http://www.apache.org/licenses/LICENSE-2.0
-    #
-    # Unless required by applicable law or agreed to in writing, software
-    # distributed under the License is distributed on an "AS IS" BASIS,
-    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    # See the License for the specific language governing permissions and
-    # limitations under the License.
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-    ${yamlencode({
+${yamlencode({
   project_id = var.project_id
   pod = {
     image = "curlimages/curl:8.4.0"
     label = "egress-test"
   }
 })}
-  EOF
+EOF
 }
 

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -1,0 +1,160 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# VPC Network
+resource "google_compute_network" "vpc" {
+  name                    = var.network_name
+  auto_create_subnetworks = false
+}
+
+# Subnet
+resource "google_compute_subnetwork" "subnet" {
+  name                     = var.subnet_name
+  ip_cidr_range            = "10.0.0.0/20"
+  region                   = var.region
+  network                  = google_compute_network.vpc.id
+  private_ip_google_access = true
+
+  secondary_ip_range {
+    range_name    = "pods"
+    ip_cidr_range = "10.4.0.0/14"
+  }
+
+  secondary_ip_range {
+    range_name    = "services"
+    ip_cidr_range = "10.8.0.0/20"
+  }
+}
+
+# Cloud NAT
+resource "google_compute_router" "router" {
+  name    = "${var.cluster_name}-router"
+  region  = var.region
+  network = google_compute_network.vpc.id
+}
+
+resource "google_compute_router_nat" "nat" {
+  name                               = "${var.cluster_name}-nat"
+  router                             = google_compute_router.router.name
+  region                             = var.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+
+# GKE Cluster
+resource "google_container_cluster" "cluster" {
+  provider = google-beta
+  name     = var.cluster_name
+  location = var.region
+
+  # MANDATORY for CI
+  deletion_protection = false
+
+  resource_labels = {
+    project  = "gcp-template-forge"
+    template = "gke-fqdn-egress-security"
+  }
+
+  network    = google_compute_network.vpc.name
+  subnetwork = google_compute_subnetwork.subnet.name
+
+  networking_mode = "VPC_NATIVE"
+  ip_allocation_policy {
+    cluster_secondary_range_name  = "pods"
+    services_secondary_range_name = "services"
+  }
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  # Dataplane V2 is required for FQDN Network Policies
+  datapath_provider = "ADVANCED_DATAPATH"
+
+  network_config {
+    enable_fqdn_network_policy = true
+  }
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  release_channel {
+    channel = "REGULAR"
+  }
+
+  # Enable GKE Enterprise features
+  security_posture_config {
+    mode               = "BASIC"
+    vulnerability_mode = "VULNERABILITY_ENTERPRISE"
+  }
+
+  timeouts {
+    create = "30m"
+    update = "30m"
+    delete = "30m"
+  }
+}
+
+resource "google_container_node_pool" "primary_nodes" {
+  name       = "fqdn-egress-pool"
+  location   = var.region
+  cluster    = google_container_cluster.cluster.name
+  node_count = 1
+
+  node_config {
+    spot         = true
+    machine_type = "e2-standard-4"
+    disk_size_gb = 50
+
+    service_account = var.service_account
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    labels = {
+      project  = "gcp-template-forge"
+      template = "gke-fqdn-egress-security"
+    }
+
+    resource_labels = {
+      project  = "gcp-template-forge"
+      template = "gke-fqdn-egress-security"
+    }
+  }
+}
+
+# Helm Release for Workload
+resource "helm_release" "workload" {
+  name       = "fqdn-egress-security"
+  chart      = "${path.module}/workload"
+  namespace  = "default"
+  depends_on = [google_container_node_pool.primary_nodes]
+
+  set {
+    name  = "project_id"
+    value = var.project_id
+  }
+}

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -182,29 +182,29 @@ resource "google_container_node_pool" "primary_nodes" {
 
 # Generate values.yaml for the Helm chart
 resource "local_file" "helm_values" {
-  content = <<EOF
-# Copyright 2026 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+  filename = "${path.module}/workload/values.yaml"
+  content = <<-EOF
+    # Copyright 2026 Google LLC
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #      http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
 
-${yamlencode({
+    ${yamlencode({
   project_id = var.project_id
   pod = {
     image = "curlimages/curl:8.4.0"
     label = "egress-test"
   }
 })}
-EOF
-  filename = "${path.module}/workload/values.yaml"
+  EOF
 }
 

--- a/templates/gke-fqdn-egress-security/terraform-helm/main.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/main.tf
@@ -49,13 +49,13 @@ resource "google_compute_subnetwork" "subnet" {
 
 # Cloud NAT
 resource "google_compute_router" "router" {
-  name    = "${var.cluster_name}-router"
+  name    = "fqdn-egress-router"
   region  = var.region
   network = google_compute_network.vpc.id
 }
 
 resource "google_compute_router_nat" "nat" {
-  name                               = "${var.cluster_name}-nat"
+  name                               = "fqdn-egress-nat"
   router                             = google_compute_router.router.name
   region                             = var.region
   nat_ip_allocate_option             = "AUTO_ONLY"

--- a/templates/gke-fqdn-egress-security/terraform-helm/outputs.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/outputs.tf
@@ -16,6 +16,10 @@ output "cluster_name" {
   value = google_container_cluster.cluster.name
 }
 
+output "cluster_location" {
+  value = google_container_cluster.cluster.location
+}
+
 output "region" {
   value = var.region
 }

--- a/templates/gke-fqdn-egress-security/terraform-helm/outputs.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/outputs.tf
@@ -1,0 +1,29 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "cluster_name" {
+  value = google_container_cluster.cluster.name
+}
+
+output "region" {
+  value = var.region
+}
+
+output "network_name" {
+  value = google_compute_network.vpc.name
+}
+
+output "subnet_name" {
+  value = google_compute_subnetwork.subnet.name
+}

--- a/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "The GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "cluster_name" {
+  description = "The name of the GKE cluster"
+  type        = string
+  default     = "fqdn-egress-cluster"
+}
+
+variable "network_name" {
+  description = "The name of the VPC network"
+  type        = string
+  default     = "fqdn-egress-vpc"
+}
+
+variable "subnet_name" {
+  description = "The name of the subnet"
+  type        = string
+  default     = "fqdn-egress-subnet"
+}
+
+variable "service_account" {
+  description = "The service account to use for the GKE nodes"
+  type        = string
+}

--- a/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
@@ -26,19 +26,19 @@ variable "region" {
 variable "cluster_name" {
   description = "The name of the GKE cluster"
   type        = string
-  default     = "gke-fqdn-egress-security-tf"
+  default     = "gke-fqdn-egress-security-cluster"
 }
 
 variable "network_name" {
   description = "The name of the VPC network"
   type        = string
-  default     = "gke-fqdn-egress-security-tf-vpc"
+  default     = "gke-fqdn-egress-security-vpc"
 }
 
 variable "subnet_name" {
   description = "The name of the subnet"
   type        = string
-  default     = "gke-fqdn-egress-security-tf-subnet"
+  default     = "gke-fqdn-egress-security-subnet"
 }
 
 variable "service_account" {

--- a/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
@@ -44,4 +44,5 @@ variable "subnet_name" {
 variable "service_account" {
   description = "The service account to use for the GKE nodes"
   type        = string
+  default     = "forge-builder@gca-gke-2025.iam.gserviceaccount.com"
 }

--- a/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
@@ -26,19 +26,23 @@ variable "region" {
 variable "cluster_name" {
   description = "The name of the GKE cluster"
   type        = string
+  default     = "gke-fqdn-egress-security-tf"
 }
 
 variable "network_name" {
   description = "The name of the VPC network"
   type        = string
+  default     = "gke-fqdn-egress-security-tf-vpc"
 }
 
 variable "subnet_name" {
   description = "The name of the subnet"
   type        = string
+  default     = "gke-fqdn-egress-security-tf-subnet"
 }
 
 variable "service_account" {
   description = "The service account to use for the GKE nodes"
   type        = string
+  default     = "forge-builder@gca-gke-2025.iam.gserviceaccount.com"
 }

--- a/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
@@ -26,19 +26,16 @@ variable "region" {
 variable "cluster_name" {
   description = "The name of the GKE cluster"
   type        = string
-  default     = "fqdn-egress-cluster"
 }
 
 variable "network_name" {
   description = "The name of the VPC network"
   type        = string
-  default     = "fqdn-egress-vpc"
 }
 
 variable "subnet_name" {
   description = "The name of the subnet"
   type        = string
-  default     = "fqdn-egress-subnet"
 }
 
 variable "service_account" {

--- a/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/variables.tf
@@ -44,5 +44,4 @@ variable "subnet_name" {
 variable "service_account" {
   description = "The service account to use for the GKE nodes"
   type        = string
-  default     = "forge-builder@gca-gke-2025.iam.gserviceaccount.com"
 }

--- a/templates/gke-fqdn-egress-security/terraform-helm/versions.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/versions.tf
@@ -23,13 +23,5 @@ terraform {
       source  = "hashicorp/google-beta"
       version = ">= 5.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.0"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = ">= 2.0"
-    }
   }
 }

--- a/templates/gke-fqdn-egress-security/terraform-helm/versions.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/versions.tf
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.0"
+  backend "gcs" {}
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
+  required_version = ">= 1.7"
 }

--- a/templates/gke-fqdn-egress-security/terraform-helm/versions.tf
+++ b/templates/gke-fqdn-egress-security/terraform-helm/versions.tf
@@ -1,0 +1,35 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/Chart.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/Chart.yaml
@@ -4,3 +4,5 @@ description: A Helm chart for GKE FQDN Network Policies demo
 type: application
 version: 0.1.0
 appVersion: "1.0.0"
+annotations:
+  project: gcp-template-forge

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/Chart.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/Chart.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v2
 name: fqdn-egress-security
 description: A Helm chart for GKE FQDN Network Policies demo

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/Chart.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: fqdn-egress-security
+description: A Helm chart for GKE FQDN Network Policies demo
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
@@ -24,8 +24,11 @@ spec:
   - matches:
     - name: anthropic.com
     - name: api.anthropic.com
+    - pattern: "*.anthropic.com"
     - name: huggingface.co
+    - pattern: "*.huggingface.co"
     - name: hf.co
+    - pattern: "*.hf.co"
     ports:
     - protocol: TCP
       port: 443

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
@@ -24,11 +24,8 @@ spec:
   - matches:
     - name: anthropic.com
     - name: api.anthropic.com
-    - name: "*.anthropic.com"
     - name: huggingface.co
-    - name: "*.huggingface.co"
     - name: hf.co
-    - name: "*.hf.co"
     ports:
     - protocol: TCP
       port: 443

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.gke.io/v1alpha1
 kind: FQDNNetworkPolicy
 metadata:

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
@@ -22,10 +22,12 @@ spec:
       app: {{ .Values.pod.label }}
   egress:
   - matches:
+    - name: anthropic.com
     - name: api.anthropic.com
     - pattern: "*.anthropic.com"
     - name: huggingface.co
     - pattern: "*.huggingface.co"
+    - name: hf.co
     - pattern: "*.hf.co"
     ports:
     - protocol: TCP

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.gke.io/v1alpha1
+kind: FQDNNetworkPolicy
+metadata:
+  name: allow-ai-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Values.pod.label }}
+  egress:
+  - to:
+    - fqdns:
+      - api.anthropic.com
+      - huggingface.co
+    ports:
+    - protocol: TCP
+      port: 443

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
@@ -7,10 +7,9 @@ spec:
     matchLabels:
       app: {{ .Values.pod.label }}
   egress:
-  - to:
-    - fqdns:
-      - api.anthropic.com
-      - huggingface.co
+  - matches:
+    - name: api.anthropic.com
+    - name: huggingface.co
     ports:
     - protocol: TCP
       port: 443

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
@@ -23,7 +23,10 @@ spec:
   egress:
   - matches:
     - name: api.anthropic.com
+    - pattern: "*.anthropic.com"
     - name: huggingface.co
+    - pattern: "*.huggingface.co"
+    - pattern: "*.hf.co"
     ports:
     - protocol: TCP
       port: 443

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
@@ -24,11 +24,11 @@ spec:
   - matches:
     - name: anthropic.com
     - name: api.anthropic.com
-    - pattern: "*.anthropic.com"
+    - name: "*.anthropic.com"
     - name: huggingface.co
-    - pattern: "*.huggingface.co"
+    - name: "*.huggingface.co"
     - name: hf.co
-    - pattern: "*.hf.co"
+    - name: "*.hf.co"
     ports:
     - protocol: TCP
       port: 443

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/network-policy.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/network-policy.yaml
@@ -8,5 +8,12 @@ spec:
       app: {{ .Values.pod.label }}
   policyTypes:
   - Egress
-  # Empty egress rule means deny all
-  egress: []
+  egress:
+  # Allow DNS resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+
+

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/network-policy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ .Values.pod.label }}
+  policyTypes:
+  - Egress
+  # Empty egress rule means deny all
+  egress: []

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/network-policy.yaml
@@ -17,13 +17,11 @@ kind: NetworkPolicy
 metadata:
   name: default-deny-egress
 spec:
-  podSelector:
-    matchLabels:
-      app: {{ .Values.pod.label }}
+  podSelector: {}
   policyTypes:
   - Egress
   egress:
-  # Allow DNS resolution
+  # Allow DNS resolution for all pods to enable FQDN resolution
   - ports:
     - protocol: UDP
       port: 53

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/verification-pod.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/verification-pod.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: egress-verifier
+  labels:
+    app: {{ .Values.pod.label }}
+spec:
+  containers:
+  - name: verifier
+    image: {{ .Values.pod.image }}
+    command: ["/bin/sh", "-c", "sleep 3600"]
+  restartPolicy: Never

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/verification-pod.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/verification-pod.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/values.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/values.yaml
@@ -1,0 +1,6 @@
+# Default values for fqdn-egress-security.
+project_id: ""
+
+pod:
+  image: python:3.9-slim
+  label: egress-test

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/values.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/values.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Default values for fqdn-egress-security.
 project_id: ""
 

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/values.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/values.yaml
@@ -2,5 +2,5 @@
 project_id: ""
 
 pod:
-  image: python:3.9-slim
+  image: curlimages/curl:8.4.0
   label: egress-test

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -119,6 +119,23 @@ if [[ "$SUCCESS" == "false" ]]; then
   exit 1
 fi
 
+echo "Testing allowed domain: hf.co..."
+SUCCESS=false
+for i in $(seq 1 $MAX_RETRIES); do
+  if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://hf.co > /dev/null; then
+    echo "SUCCESS: hf.co is reachable (attempt $i)."
+    SUCCESS=true
+    break
+  fi
+  echo "Attempt $i: hf.co not reachable yet, retrying in 5s..."
+  sleep 5
+done
+
+if [[ "$SUCCESS" == "false" ]]; then
+  echo "FAILURE: hf.co is NOT reachable after $MAX_RETRIES attempts."
+  exit 1
+fi
+
 echo "Testing blocked domain: google.com..."
 if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://google.com > /dev/null 2>&1; then
   echo "FAILURE: google.com is reachable, but should be blocked!"

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -62,7 +62,7 @@ echo "Verifier pod is ready."
 echo "Test 5: Running Egress Tests..."
 
 echo "Testing allowed domain: api.anthropic.com..."
-if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sfL --connect-timeout 5 https://api.anthropic.com > /dev/null; then
+if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sL --connect-timeout 5 https://api.anthropic.com > /dev/null; then
   echo "SUCCESS: api.anthropic.com is reachable."
 else
   echo "FAILURE: api.anthropic.com is NOT reachable."
@@ -70,7 +70,7 @@ else
 fi
 
 echo "Testing allowed domain: huggingface.co..."
-if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sfL --connect-timeout 5 https://huggingface.co > /dev/null; then
+if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sL --connect-timeout 5 https://huggingface.co > /dev/null; then
   echo "SUCCESS: huggingface.co is reachable."
 else
   echo "FAILURE: huggingface.co is NOT reachable."
@@ -78,7 +78,7 @@ else
 fi
 
 echo "Testing blocked domain: google.com..."
-if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sfL --connect-timeout 5 https://google.com > /dev/null 2>&1; then
+if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sL --connect-timeout 5 https://google.com > /dev/null 2>&1; then
   echo "FAILURE: google.com is reachable, but should be blocked!"
   exit 1
 else

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -22,7 +22,7 @@ CLUSTER_NAME=${CLUSTER_NAME:-"gke-fqdn-egress-security-cluster"}
 REGION=${REGION:-"us-central1"}
 NAMESPACE=${NAMESPACE:-"default"}
 
-# Isolate KUBECONFIG
+# Isolate KUBECONFIG to avoid affecting other clusters
 export KUBECONFIG=$(mktemp)
 trap 'rm -f "$KUBECONFIG"' EXIT
 

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -55,6 +55,14 @@ echo "FQDNNetworkPolicy resource found."
 
 # 4. Wait for Verifier Pod
 echo "Test 4: Waiting for Egress Verifier Pod..."
+# Wait for pod to exist
+for i in {1..10}; do
+  if kubectl get pod egress-verifier -n ${NAMESPACE} > /dev/null 2>&1; then
+    break
+  fi
+  echo "Waiting for egress-verifier pod to be created (attempt $i/10)..."
+  sleep 10
+done
 kubectl wait --for=condition=Ready pod/egress-verifier -n ${NAMESPACE} --timeout=5m
 echo "Verifier pod is ready."
 

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -78,23 +78,49 @@ echo "Verifier pod is ready."
 echo "Test 5: Running Egress Tests..."
 
 echo "Testing allowed domain: api.anthropic.com..."
-if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL --connect-timeout 5 https://api.anthropic.com > /dev/null; then
-  echo "SUCCESS: api.anthropic.com is reachable."
-else
-  echo "FAILURE: api.anthropic.com is NOT reachable."
+# Dataplane V2 FQDN policies sometimes need a few seconds to learn the IP from the first DNS response.
+# We use a retry loop to account for this.
+MAX_RETRIES=5
+SUCCESS=false
+for i in $(seq 1 $MAX_RETRIES); do
+  if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://api.anthropic.com > /dev/null; then
+    echo "SUCCESS: api.anthropic.com is reachable (attempt $i)."
+    SUCCESS=true
+    break
+  fi
+  echo "Attempt $i: api.anthropic.com not reachable yet, retrying in 5s..."
+  sleep 5
+done
+
+if [[ "$SUCCESS" == "false" ]]; then
+  echo "FAILURE: api.anthropic.com is NOT reachable after $MAX_RETRIES attempts."
+  # Debug: dump policy status and DNS resolution
+  echo "--- DEBUG INFO ---"
+  kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}" -o yaml || true
+  kubectl exec egress-verifier -n "${NAMESPACE}" -- nslookup api.anthropic.com || true
+  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://api.anthropic.com || true
   exit 1
 fi
 
 echo "Testing allowed domain: huggingface.co..."
-if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL --connect-timeout 5 https://huggingface.co > /dev/null; then
-  echo "SUCCESS: huggingface.co is reachable."
-else
-  echo "FAILURE: huggingface.co is NOT reachable."
+SUCCESS=false
+for i in $(seq 1 $MAX_RETRIES); do
+  if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://huggingface.co > /dev/null; then
+    echo "SUCCESS: huggingface.co is reachable (attempt $i)."
+    SUCCESS=true
+    break
+  fi
+  echo "Attempt $i: huggingface.co not reachable yet, retrying in 5s..."
+  sleep 5
+done
+
+if [[ "$SUCCESS" == "false" ]]; then
+  echo "FAILURE: huggingface.co is NOT reachable after $MAX_RETRIES attempts."
   exit 1
 fi
 
 echo "Testing blocked domain: google.com..."
-if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL --connect-timeout 5 https://google.com > /dev/null 2>&1; then
+if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://google.com > /dev/null 2>&1; then
   echo "FAILURE: google.com is reachable, but should be blocked!"
   exit 1
 else

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -97,8 +97,10 @@ if [[ "$SUCCESS" == "false" ]]; then
   # Debug: dump policy status and DNS resolution
   echo "--- DEBUG INFO ---"
   kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}" -o yaml || true
-  kubectl exec egress-verifier -n "${NAMESPACE}" -- nslookup api.anthropic.com || true
-  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://api.anthropic.com || true
+  echo "Checking if we can reach the pod at all..."
+  kubectl get pod egress-verifier -n "${NAMESPACE}" -o wide || true
+  echo "Attempting a direct curl with verbose output..."
+  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://api.anthropic.com || echo "kubectl exec failed (check master-to-node connectivity on port 10250)"
   exit 1
 fi
 

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -55,7 +55,7 @@ echo "FQDNNetworkPolicy resource found."
 
 # 4. Wait for Verifier Pod
 echo "Test 4: Waiting for Egress Verifier Pod..."
-# Wait for pod to exist
+# Wait for pod to exist (up to 200 seconds)
 POD_FOUND=false
 for i in {1..20}; do
   if kubectl get pod egress-verifier -n "${NAMESPACE}" > /dev/null 2>&1; then

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -euo pipefail
 
 echo "Starting GKE FQDN Network Policy Validation Tests..."
 
@@ -28,21 +28,21 @@ trap 'rm -f "$KUBECONFIG"' EXIT
 
 # 1. Cluster Connectivity
 echo "Test 1: Cluster Connectivity..."
-gcloud container clusters get-credentials ${CLUSTER_NAME} --region ${REGION} --project ${PROJECT_ID}
+gcloud container clusters get-credentials "${CLUSTER_NAME}" --region "${REGION}" --project "${PROJECT_ID}"
 kubectl cluster-info
 echo "Connectivity passed."
 
 # 2. Dataplane V2 and FQDN Policy Enablement
 echo "Test 2: Verifying Dataplane V2 and FQDN Policy Enablement..."
-CLUSTER_DESC=$(gcloud container clusters describe ${CLUSTER_NAME} --region ${REGION} --project ${PROJECT_ID} --format=json)
-DATAPATH=$(echo $CLUSTER_DESC | jq -r '.networkConfig.datapathProvider')
-FQDN_ENABLED=$(echo $CLUSTER_DESC | jq -r '.networkConfig.enableFqdnNetworkPolicy')
+CLUSTER_DESC=$(gcloud container clusters describe "${CLUSTER_NAME}" --region "${REGION}" --project "${PROJECT_ID}" --format=json)
+DATAPATH=$(echo "${CLUSTER_DESC}" | jq -r '.networkConfig.datapathProvider')
+FQDN_ENABLED=$(echo "${CLUSTER_DESC}" | jq -r '.networkConfig.enableFqdnNetworkPolicy')
 
-if [ "$DATAPATH" != "ADVANCED_DATAPATH" ]; then
+if [[ "$DATAPATH" != "ADVANCED_DATAPATH" ]]; then
   echo "Dataplane V2 check failed! Provider: $DATAPATH"
   exit 1
 fi
-if [ "$FQDN_ENABLED" != "true" ]; then
+if [[ "$FQDN_ENABLED" != "true" ]]; then
   echo "FQDN Network Policy check failed! Enabled: $FQDN_ENABLED"
   exit 1
 fi
@@ -50,27 +50,35 @@ echo "Dataplane V2 and FQDN Policy enablement validated."
 
 # 3. FQDNNetworkPolicy Resource Verification
 echo "Test 3: Verifying FQDNNetworkPolicy Resource..."
-kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n ${NAMESPACE}
+kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}"
 echo "FQDNNetworkPolicy resource found."
 
 # 4. Wait for Verifier Pod
 echo "Test 4: Waiting for Egress Verifier Pod..."
 # Wait for pod to exist
-for i in {1..10}; do
-  if kubectl get pod egress-verifier -n ${NAMESPACE} > /dev/null 2>&1; then
+POD_FOUND=false
+for i in {1..20}; do
+  if kubectl get pod egress-verifier -n "${NAMESPACE}" > /dev/null 2>&1; then
+    POD_FOUND=true
     break
   fi
-  echo "Waiting for egress-verifier pod to be created (attempt $i/10)..."
+  echo "Waiting for egress-verifier pod to be created (attempt $i/20)..."
   sleep 10
 done
-kubectl wait --for=condition=Ready pod/egress-verifier -n ${NAMESPACE} --timeout=5m
+
+if [[ "$POD_FOUND" == "false" ]]; then
+  echo "FAILURE: egress-verifier pod was never created!"
+  exit 1
+fi
+
+kubectl wait --for=condition=Ready pod/egress-verifier -n "${NAMESPACE}" --timeout=5m
 echo "Verifier pod is ready."
 
 # 5. Egress Tests
 echo "Test 5: Running Egress Tests..."
 
 echo "Testing allowed domain: api.anthropic.com..."
-if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sL --connect-timeout 5 https://api.anthropic.com > /dev/null; then
+if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL --connect-timeout 5 https://api.anthropic.com > /dev/null; then
   echo "SUCCESS: api.anthropic.com is reachable."
 else
   echo "FAILURE: api.anthropic.com is NOT reachable."
@@ -78,7 +86,7 @@ else
 fi
 
 echo "Testing allowed domain: huggingface.co..."
-if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sL --connect-timeout 5 https://huggingface.co > /dev/null; then
+if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL --connect-timeout 5 https://huggingface.co > /dev/null; then
   echo "SUCCESS: huggingface.co is reachable."
 else
   echo "FAILURE: huggingface.co is NOT reachable."
@@ -86,7 +94,7 @@ else
 fi
 
 echo "Testing blocked domain: google.com..."
-if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sL --connect-timeout 5 https://google.com > /dev/null 2>&1; then
+if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL --connect-timeout 5 https://google.com > /dev/null 2>&1; then
   echo "FAILURE: google.com is reachable, but should be blocked!"
   exit 1
 else

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+echo "Starting GKE FQDN Network Policy Validation Tests..."
+
+PROJECT_ID=${PROJECT_ID:-"gca-gke-2025"}
+CLUSTER_NAME=${CLUSTER_NAME:-"fqdn-egress-cluster"}
+REGION=${REGION:-"us-central1"}
+NAMESPACE=${NAMESPACE:-"default"}
+
+# Isolate KUBECONFIG
+export KUBECONFIG=$(mktemp)
+trap 'rm -f "$KUBECONFIG"' EXIT
+
+# 1. Cluster Connectivity
+echo "Test 1: Cluster Connectivity..."
+gcloud container clusters get-credentials ${CLUSTER_NAME} --region ${REGION} --project ${PROJECT_ID}
+kubectl cluster-info
+echo "Connectivity passed."
+
+# 2. Dataplane V2 and FQDN Policy Enablement
+echo "Test 2: Verifying Dataplane V2 and FQDN Policy Enablement..."
+CLUSTER_DESC=$(gcloud container clusters describe ${CLUSTER_NAME} --region ${REGION} --project ${PROJECT_ID} --format=json)
+DATAPATH=$(echo $CLUSTER_DESC | jq -r '.networkConfig.datapathProvider')
+FQDN_ENABLED=$(echo $CLUSTER_DESC | jq -r '.networkConfig.enableFqdnNetworkPolicy')
+
+if [ "$DATAPATH" != "ADVANCED_DATAPATH" ]; then
+  echo "Dataplane V2 check failed! Provider: $DATAPATH"
+  exit 1
+fi
+if [ "$FQDN_ENABLED" != "true" ]; then
+  echo "FQDN Network Policy check failed! Enabled: $FQDN_ENABLED"
+  exit 1
+fi
+echo "Dataplane V2 and FQDN Policy enablement validated."
+
+# 3. FQDNNetworkPolicy Resource Verification
+echo "Test 3: Verifying FQDNNetworkPolicy Resource..."
+kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n ${NAMESPACE}
+echo "FQDNNetworkPolicy resource found."
+
+# 4. Wait for Verifier Pod
+echo "Test 4: Waiting for Egress Verifier Pod..."
+kubectl wait --for=condition=Ready pod/egress-verifier -n ${NAMESPACE} --timeout=5m
+echo "Verifier pod is ready."
+
+# 5. Egress Tests
+echo "Test 5: Running Egress Tests..."
+
+echo "Testing allowed domain: api.anthropic.com..."
+if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sfL --connect-timeout 5 https://api.anthropic.com > /dev/null; then
+  echo "SUCCESS: api.anthropic.com is reachable."
+else
+  echo "FAILURE: api.anthropic.com is NOT reachable."
+  exit 1
+fi
+
+echo "Testing allowed domain: huggingface.co..."
+if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sfL --connect-timeout 5 https://huggingface.co > /dev/null; then
+  echo "SUCCESS: huggingface.co is reachable."
+else
+  echo "FAILURE: huggingface.co is NOT reachable."
+  exit 1
+fi
+
+echo "Testing blocked domain: google.com..."
+if kubectl exec egress-verifier -n ${NAMESPACE} -- curl -sfL --connect-timeout 5 https://google.com > /dev/null 2>&1; then
+  echo "FAILURE: google.com is reachable, but should be blocked!"
+  exit 1
+else
+  echo "SUCCESS: google.com is blocked as expected."
+fi
+
+echo "All GKE FQDN Network Policy Validation Tests passed successfully!"

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -18,7 +18,7 @@ set -e
 echo "Starting GKE FQDN Network Policy Validation Tests..."
 
 PROJECT_ID=${PROJECT_ID:-"gca-gke-2025"}
-CLUSTER_NAME=${CLUSTER_NAME:-"fqdn-egress-cluster"}
+CLUSTER_NAME=${CLUSTER_NAME:-"gke-fqdn-egress-security-cluster"}
 REGION=${REGION:-"us-central1"}
 NAMESPACE=${NAMESPACE:-"default"}
 

--- a/templates/gke-fqdn-egress-security/verification_plan.md
+++ b/templates/gke-fqdn-egress-security/verification_plan.md
@@ -1,0 +1,34 @@
+# Verification Plan: GKE FQDN Network Policies
+
+This plan outlines the steps to verify the implementation of GKE FQDN Network Policies for secure AI egress.
+
+## Prerequisites
+- GCP Project with GKE Enterprise enabled (or trial).
+- Terraform and kubectl installed.
+
+## Infrastructure Verification
+1.  **Dataplane V2:** Ensure the cluster is created with `datapathProvider: ADVANCED_DATAPATH`.
+2.  **FQDN Policy Flag:** Ensure `enableFqdnNetworkPolicy: true` is set in the cluster configuration.
+3.  **Network Topology:** Verify private nodes are used with Cloud NAT for external access.
+
+## Workload Verification
+1.  **Default Deny:**
+    -   Apply the `NetworkPolicy` that denies all egress for pods labeled `app: egress-test`.
+    -   Verify that without any other policies, all external `curl` commands fail.
+2.  **FQDN Allow-list:**
+    -   Apply the `FQDNNetworkPolicy` allowing `api.anthropic.com` and `huggingface.co`.
+    -   Verify `curl https://api.anthropic.com` returns a successful response (likely a 401 or similar from the API, but not a connection timeout).
+    -   Verify `curl https://huggingface.co` succeeds.
+    -   Verify `curl https://google.com` is actively blocked by the CNI.
+
+## Automated Validation
+Run the provided `validate.sh` script which automates these checks:
+```bash
+./validate.sh
+```
+
+## Success Criteria
+- Cluster has Dataplane V2 and FQDN policies enabled.
+- `FQDNNetworkPolicy` resource is successfully admitted by the GKE control plane.
+- Egress to allowed FQDNs is successful.
+- Egress to non-allowed FQDNs is blocked.


### PR DESCRIPTION
This PR adds a new template for GKE demonstrating Zero-Trust AI egress using FQDN Network Policies.

### Summary
The 'gke-fqdn-egress-security' template provides a complete setup for implementing fine-grained egress control for AI workloads. It leverages GKE Dataplane V2 and the FQDN Network Policy feature (GKE Enterprise) to allow traffic to specific external domains without the need for managing static IP allow-lists.

### Key Components
- **Infrastructure:** GKE Cluster with Dataplane V2 and GKE Enterprise Advanced Networking enabled via Terraform and KCC.
- **Security Policies:** 
    - A standard 'NetworkPolicy' for Default Deny Egress.
    - An 'FQDNNetworkPolicy' to selectively allow egress to 'api.anthropic.com' and 'huggingface.co'.
- **Validation:** A verification pod and a 'validate.sh' script to confirm that allowed domains are reachable while unauthorized domains (like google.com) are blocked.

Fixes #33

Generated by **Overseer** (powered by the gemini-3-flash-preview model).