### PR TITLE
Make cleanup workflow generic for all networking resources

### DIFF
--- a/.github/workflows/cleanup-orphans.yml
+++ b/.github/workflows/cleanup-orphans.yml
@@ -180,8 +180,8 @@ jobs:
           # 3. Clean up Networking resources (matching pattern)
           echo "Cleaning up orphaned Networking resources (matching pattern)..."
           
-          # Firewalls (BROADER PATTERN to catch gke- prefix)
-          FIREWALLS=$(gcloud compute firewall-rules list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+          # Firewalls (Generic exclusion)
+          FIREWALLS=$(gcloud compute firewall-rules list --project=$PROJECT --format="value(name)" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete|default" || true)
           for F in $FIREWALLS; do
             SKIP=false
             for PAT in $ALL_ACTIVE; do
@@ -202,7 +202,7 @@ jobs:
           ALL_ROUTERS=$(gcloud compute routers list --project=$PROJECT --format="value(name, region)")
           
           for RGN in $REGIONS; do
-            ROUTERS=$(echo "$ALL_ROUTERS" | grep "$RGN" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" | awk '{print $1}' || true)
+            ROUTERS=$(echo "$ALL_ROUTERS" | grep "$RGN" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete|default" | awk '{print $1}' || true)
             for R in $ROUTERS; do
               SKIP=false
               for PAT in $ALL_ACTIVE; do
@@ -230,7 +230,7 @@ jobs:
           ALL_SUBNETS=$(gcloud compute networks subnets list --project=$PROJECT --format="value(name, region)")
           
           for RGN in $REGIONS; do
-            SUBNETS=$(echo "$ALL_SUBNETS" | grep "$RGN" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" | awk '{print $1}' || true)
+            SUBNETS=$(echo "$ALL_SUBNETS" | grep "$RGN" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete|default" | awk '{print $1}' || true)
             for S in $SUBNETS; do
               SKIP=false
               for PAT in $ALL_ACTIVE; do
@@ -250,7 +250,7 @@ jobs:
           echo "Listing all networks in project..."
           gcloud compute networks list --project=$PROJECT
 
-          NETWORKS=$(gcloud compute networks list --project=$PROJECT --format="value(name)" | grep -E "latest-gke-features-|enterprise-gke-|basic-gke-" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete" || true)
+          NETWORKS=$(gcloud compute networks list --project=$PROJECT --format="value(name)" | grep -v -E "repo-agent-standard|krmapihost-kcc-instance|kcc-dash-dont-delete|default" || true)
           for N in $NETWORKS; do
             SKIP=false
             for PAT in $ALL_ACTIVE; do

--- a/.github/workflows/cleanup-orphans.yml
+++ b/.github/workflows/cleanup-orphans.yml
@@ -149,12 +149,10 @@ jobs:
           while read -r NEG_NAME NEG_ZONE NEG_NET; do
             [ -z "$NEG_NAME" ] && continue
             
-            # Check if the network matches our pattern
-            if [[ "$NEG_NET" =~ "latest-gke-features-" || "$NEG_NET" =~ "enterprise-gke-" || "$NEG_NET" =~ "basic-gke-" ]]; then
-              # Check safe-list
-              if [[ "$NEG_NET" =~ "repo-agent-standard" || "$NEG_NET" =~ "krmapihost-kcc-instance" || "$NEG_NET" =~ "kcc-dash-dont-delete" ]]; then
-                continue
-              fi
+            # Check safe-list (Generic exclusion)
+            if [[ "$NEG_NET" =~ "repo-agent-standard" || "$NEG_NET" =~ "krmapihost-kcc-instance" || "$NEG_NET" =~ "kcc-dash-dont-delete" || "$NEG_NET" =~ "default" ]]; then
+              continue
+            fi
               
               # Check active runs
               SKIP=false


### PR DESCRIPTION
This PR removes hardcoded template prefixes from the cleanup script and replaces them with a generic exclusion list. This ensures that all orphaned networking resources (Firewalls, Routers, Subnets, Networks) are cleaned up, regardless of the template name, while still protecting management resources.