### PR TITLE
Fix syntax error in cleanup-orphans.yml

### DIFF
--- a/.github/workflows/cleanup-orphans.yml
+++ b/.github/workflows/cleanup-orphans.yml
@@ -172,7 +172,6 @@ jobs:
               else
                 delete_resource "gcloud compute network-endpoint-groups delete $NEG_NAME --global --project=$PROJECT --quiet" "NEG $NEG_NAME"
               fi
-            fi
           done <<< "$ALL_NEGS"
 
           # 3. Clean up Networking resources (matching pattern)


### PR DESCRIPTION
This PR fixes a syntax error (orphaned 'fi') in the NEG cleanup loop introduced in the previous PR.