### PR TITLE
Fix active run protection for resources with suffixes

### DIFF
--- a/.github/workflows/cleanup-orphans.yml
+++ b/.github/workflows/cleanup-orphans.yml
@@ -82,7 +82,11 @@ jobs:
           ACTIVE_SHAS=$(gh run list --status in_progress --json headSha -q '.[].headSha' | cut -c1-5 || true)
           QUEUED_SHAS=$(gh run list --status queued --json headSha -q '.[].headSha' | cut -c1-5 || true)
           
-          ALL_ACTIVE="$ACTIVE_RUNS $QUEUED_RUNS $ACTIVE_SHAS $QUEUED_SHAS"
+          # Get last 6 digits of run IDs (resources use this as suffix)
+          ACTIVE_SUFFIXES=$(gh run list --status in_progress --json databaseId -q '.[].databaseId' | awk '{if (length($0) >= 6) print substr($0, length($0)-5); else print $0}' || true)
+          QUEUED_SUFFIXES=$(gh run list --status queued --json databaseId -q '.[].databaseId' | awk '{if (length($0) >= 6) print substr($0, length($0)-5); else print $0}' || true)
+          
+          ALL_ACTIVE="$ACTIVE_RUNS $QUEUED_RUNS $ACTIVE_SHAS $QUEUED_SHAS $ACTIVE_SUFFIXES $QUEUED_SUFFIXES"
 
           if [ -n "$ALL_ACTIVE" ]; then
             echo "Found active/queued runs/patterns: $ALL_ACTIVE. Cleanup will skip these."


### PR DESCRIPTION
This PR adds the last 6 digits of active run IDs to the protection list in the cleanup script. This ensures that resources named with run ID suffixes are correctly identified as active and not deleted.