### PR TITLE
ci: use github.token and add write permission for PRs

### DIFF
--- a/.github/workflows/detect-conflicts.yml
+++ b/.github/workflows/detect-conflicts.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   detect-and-label:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - name: Detect Conflicting PRs and Label
         run: |
@@ -18,5 +21,5 @@ jobs:
             gh pr edit $pr_num --repo fkc1e100/gcp-template-forge --add-label "needs-rebase"
           done
         env:
-          GH_TOKEN: ${{ secrets.CODEBOT_PAT }} # Using GH_TOKEN for sufficient permissions
+          GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
This PR updates the conflict detection workflow to use github.token and adds pull-requests: write permission to the job, ensuring it can label PRs without custom secrets.