### PR TITLE
[Bug] Fix README for gke-fqdn-egress-security KCC deployment details

### DIFF
--- a/.github/workflows/sandbox-validation.yml
+++ b/.github/workflows/sandbox-validation.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Remove repo-agent Label on Start
         if: github.event_name == 'pull_request'
-        run: gh pr edit ${{ github.event.number }} --remove-label "repo-agent" || true
+        run: gh pr edit ${{ github.event.number }} --remove-label "repo-agent" --repo ${{ github.repository }} || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -495,7 +495,7 @@ jobs:
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr edit ${{ github.event.number }} --add-label "repo-agent" && gh run cancel ${{ github.run_id }}
+        run: gh pr edit ${{ github.event.number }} --add-label "repo-agent" --repo ${{ github.repository }} && gh run cancel ${{ github.run_id }}
 
   # ── 4b. PR: KCC deploy → wait → delete (parallel with deploy-test-tf) ─────
   kcc-apply:
@@ -1651,7 +1651,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add repo-agent label
-        run: gh pr edit ${{ github.event.number }} --add-label "repo-agent"
+        run: gh pr edit ${{ github.event.number }} --add-label "repo-agent" --repo ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/sandbox-validation.yml
+++ b/.github/workflows/sandbox-validation.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Remove repo-agent Label on Start
         if: github.event_name == 'pull_request'
-        run: gh pr edit ${{ github.event.number }} --remove-label "repo-agent" --repo ${{ github.repository }} || true
+        run: gh pr edit ${{ github.event.number }} --remove-label "repo-agent" || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -495,7 +495,7 @@ jobs:
         if: failure()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr edit ${{ github.event.number }} --add-label "repo-agent" --repo ${{ github.repository }} && gh run cancel ${{ github.run_id }}
+        run: gh pr edit ${{ github.event.number }} --add-label "repo-agent" && gh run cancel ${{ github.run_id }}
 
   # ── 4b. PR: KCC deploy → wait → delete (parallel with deploy-test-tf) ─────
   kcc-apply:
@@ -1651,7 +1651,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add repo-agent label
-        run: gh pr edit ${{ github.event.number }} --add-label "repo-agent" --repo ${{ github.repository }}
+        run: gh pr edit ${{ github.event.number }} --add-label "repo-agent"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -15,9 +15,9 @@ Securing egress traffic is a critical component of a Zero-Trust architecture. In
 - **GKE Cluster:** A private cluster with Dataplane V2 and FQDN Network Policy enabled.
 - **NetworkPolicy (`default-deny-egress`):** Denies all egress except for DNS (UDP/TCP 53) to allow FQDN resolution. *Note: This blocks communication with the Kubernetes API server by default, which is acceptable for this validation pod but may require an exception for production workloads.*
 - **FQDNNetworkPolicy (`allow-ai-egress`):** Allows HTTPS (TCP 443) traffic to:
-    - `anthropic.com`, `api.anthropic.com`, `*.anthropic.com`
-    - `huggingface.co`, `*.huggingface.co`
-    - `hf.co`, `*.hf.co`
+    - `anthropic.com`, `api.anthropic.com`, `www.anthropic.com`, `*.anthropic.com`
+    - `huggingface.co`, `api.huggingface.co`, `*.huggingface.co`
+    - `hf.co`, `www.hf.co`, `*.hf.co`
     *Note: The GKE FQDN controller intercepts DNS queries from the pods to learn the IP addresses associated with these domains. The first few requests after a policy is applied may experience slight latency as the eBPF maps are populated.*
 - **Validation Pod:** A `curl`-based pod used to verify connectivity.
 

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -102,7 +102,11 @@ The included `validate.sh` script automates the entire verification process, inc
     ```bash
     kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://huggingface.co
     ```
-3.  **Test Blocked Egress (Google):**
+3.  **Test Allowed Egress (hf.co):**
+    ```bash
+    kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://hf.co
+    ```
+4.  **Test Blocked Egress (Google):**
     ```bash
     kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://google.com
     # This should time out or return an error.

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -107,6 +107,7 @@ The included `validate.sh` script automates the entire verification process, inc
 3.  **Test Allowed Egress (hf.co):**
     ```bash
     kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://hf.co
+    kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://www.hf.co
     ```
 4.  **Test Blocked Egress (Google):**
     ```bash

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -97,6 +97,7 @@ The included `validate.sh` script automates the entire verification process, inc
 1.  **Test Allowed Egress (Anthropic):**
     ```bash
     kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://anthropic.com
+    kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://www.anthropic.com
     kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://api.anthropic.com
     ```
 2.  **Test Allowed Egress (HuggingFace):**

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -16,7 +16,7 @@ Securing egress traffic is a critical component of a Zero-Trust architecture. In
 - **NetworkPolicy (`default-deny-egress`):** Denies all egress except for DNS (UDP/TCP 53) to allow FQDN resolution. *Note: This blocks communication with the Kubernetes API server by default, which is acceptable for this validation pod but may require an exception for production workloads.*
 - **FQDNNetworkPolicy (`allow-ai-egress`):** Allows HTTPS (TCP 443) traffic to:
     - `anthropic.com`, `api.anthropic.com`, `www.anthropic.com`, `*.anthropic.com`
-    - `huggingface.co`, `api.huggingface.co`, `www.huggingface.co`, `*.huggingface.co`
+    - `huggingface.co`, `www.huggingface.co`, `*.huggingface.co`
     - `hf.co`, `www.hf.co`, `*.hf.co`
     *Note: The GKE FQDN controller intercepts DNS queries from the pods to learn the IP addresses associated with these domains. The first few requests after a policy is applied may experience slight latency as the eBPF maps are populated.*
 - **Validation Pod:** A `curl`-based pod used to verify connectivity.
@@ -104,7 +104,6 @@ The included `validate.sh` script automates the entire verification process, inc
     ```bash
     kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://huggingface.co
     kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://www.huggingface.co
-    kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://api.huggingface.co
     ```
 3.  **Test Allowed Egress (hf.co):**
     ```bash

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -38,8 +38,19 @@ This path uses Terraform to provision the infrastructure and Helm to deploy the 
     terraform init
     terraform apply
     ```
-2.  **Verify Workload Deployment:**
-    Terraform generates a `values.yaml` for Helm. The CI pipeline or a manual `helm install` will deploy the manifests in the `workload/` directory.
+
+2.  **Deploy Workload:**
+    Terraform generates a `values.yaml` for Helm. After the infrastructure is ready, get credentials and install the chart:
+    ```bash
+    # Get credentials for the new cluster
+    gcloud container clusters get-credentials gke-fqdn-egress-security-cluster --region us-central1
+
+    # Install the workload via Helm
+    helm install fqdn-egress ./workload
+
+    # Wait for the verifier pod to be ready
+    kubectl wait --for=condition=Ready pod/egress-verifier --timeout=5m
+    ```
 
 ### Option 2: Config Connector
 This path uses Kubernetes manifests to manage both the GCP infrastructure and the GKE workloads.

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -102,6 +102,7 @@ The included `validate.sh` script automates the entire verification process, inc
 2.  **Test Allowed Egress (HuggingFace):**
     ```bash
     kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://huggingface.co
+    kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://api.huggingface.co
     ```
 3.  **Test Allowed Egress (hf.co):**
     ```bash

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -57,11 +57,18 @@ This path uses Kubernetes manifests to manage both the GCP infrastructure and th
     *Note: After the cluster is ready, it may take an additional 2-3 minutes for GKE Enterprise features (like FQDN Network Policies) to propagate across the fleet.*
 
 3.  **Deploy Workload:**
-    Once the cluster is ready, get credentials and apply the workload manifests:
+    Once the cluster is ready, get credentials and apply the workload manifests (including the `egress-verifier` pod and the FQDN security policies):
     ```bash
+    # Get credentials for the new cluster
     gcloud container clusters get-credentials gke-fqdn-egress-security-cluster --region us-central1
+
+    # Apply the FQDN policies and the verifier pod
     kubectl apply -f config-connector-workload/
+
+    # Wait for the verifier pod to be ready
+    kubectl wait --for=condition=Ready pod/egress-verifier --timeout=5m
     ```
+    *Note: If you receive an error about `FQDNNetworkPolicy` not being found, wait 2-3 minutes for the GKE FQDN controller to initialize the CRDs and try applying again.*
 
 ## Verification
 
@@ -74,17 +81,19 @@ The included `validate.sh` script automates the entire verification process, inc
 ### Manual Verification
 *Note: If you deployed using the default settings, the namespace will be `default`.*
 
+**Important:** Dataplane V2 FQDN policies intercept DNS queries to learn IP addresses. The first few requests after a policy is applied or a DNS record TTL expires may experience slight latency or a "Connection Refused" while the eBPF maps are populated. Always retry the verification commands a few times if they fail initially.
+
 1.  **Test Allowed Egress (Anthropic):**
     ```bash
-    kubectl exec egress-verifier -n <namespace> -- curl -sL -4 --connect-timeout 10 https://api.anthropic.com
+    kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://api.anthropic.com
     ```
 2.  **Test Allowed Egress (HuggingFace):**
     ```bash
-    kubectl exec egress-verifier -n <namespace> -- curl -sL -4 --connect-timeout 10 https://huggingface.co
+    kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://huggingface.co
     ```
 3.  **Test Blocked Egress (Google):**
     ```bash
-    kubectl exec egress-verifier -n <namespace> -- curl -sL -4 --connect-timeout 10 https://google.com
+    kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://google.com
     # This should time out or return an error.
     ```
 

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -16,7 +16,7 @@ Securing egress traffic is a critical component of a Zero-Trust architecture. In
 - **NetworkPolicy (`default-deny-egress`):** Denies all egress except for DNS (UDP/TCP 53) to allow FQDN resolution. *Note: This blocks communication with the Kubernetes API server by default, which is acceptable for this validation pod but may require an exception for production workloads.*
 - **FQDNNetworkPolicy (`allow-ai-egress`):** Allows HTTPS (TCP 443) traffic to:
     - `anthropic.com`, `api.anthropic.com`, `www.anthropic.com`, `*.anthropic.com`
-    - `huggingface.co`, `api.huggingface.co`, `*.huggingface.co`
+    - `huggingface.co`, `api.huggingface.co`, `www.huggingface.co`, `*.huggingface.co`
     - `hf.co`, `www.hf.co`, `*.hf.co`
     *Note: The GKE FQDN controller intercepts DNS queries from the pods to learn the IP addresses associated with these domains. The first few requests after a policy is applied may experience slight latency as the eBPF maps are populated.*
 - **Validation Pod:** A `curl`-based pod used to verify connectivity.
@@ -103,6 +103,7 @@ The included `validate.sh` script automates the entire verification process, inc
 2.  **Test Allowed Egress (HuggingFace):**
     ```bash
     kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://huggingface.co
+    kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://www.huggingface.co
     kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://api.huggingface.co
     ```
 3.  **Test Allowed Egress (hf.co):**

--- a/templates/gke-fqdn-egress-security/README.md
+++ b/templates/gke-fqdn-egress-security/README.md
@@ -96,6 +96,7 @@ The included `validate.sh` script automates the entire verification process, inc
 
 1.  **Test Allowed Egress (Anthropic):**
     ```bash
+    kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://anthropic.com
     kubectl exec egress-verifier -- curl -sL -4 --connect-timeout 10 https://api.anthropic.com
     ```
 2.  **Test Allowed Egress (HuggingFace):**

--- a/templates/gke-fqdn-egress-security/config-connector-workload/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector-workload/fqdn-network-policy.yaml
@@ -31,6 +31,7 @@ spec:
     - pattern: "*.anthropic.com"
     - name: huggingface.co
     - name: api.huggingface.co
+    - name: www.huggingface.co
     - pattern: "*.huggingface.co"
     - name: hf.co
     - name: www.hf.co

--- a/templates/gke-fqdn-egress-security/config-connector-workload/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector-workload/fqdn-network-policy.yaml
@@ -30,7 +30,6 @@ spec:
     - name: www.anthropic.com
     - pattern: "*.anthropic.com"
     - name: huggingface.co
-    - name: api.huggingface.co
     - name: www.huggingface.co
     - pattern: "*.huggingface.co"
     - name: hf.co

--- a/templates/gke-fqdn-egress-security/config-connector-workload/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/config-connector-workload/fqdn-network-policy.yaml
@@ -27,10 +27,13 @@ spec:
   - matches:
     - name: anthropic.com
     - name: api.anthropic.com
+    - name: www.anthropic.com
     - pattern: "*.anthropic.com"
     - name: huggingface.co
+    - name: api.huggingface.co
     - pattern: "*.huggingface.co"
     - name: hf.co
+    - name: www.hf.co
     - pattern: "*.hf.co"
     ports:
     - protocol: TCP

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
@@ -31,6 +31,7 @@ spec:
     - pattern: "*.anthropic.com"
     - name: huggingface.co
     - name: api.huggingface.co
+    - name: www.huggingface.co
     - pattern: "*.huggingface.co"
     - name: hf.co
     - name: www.hf.co

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
@@ -30,7 +30,6 @@ spec:
     - name: www.anthropic.com
     - pattern: "*.anthropic.com"
     - name: huggingface.co
-    - name: api.huggingface.co
     - name: www.huggingface.co
     - pattern: "*.huggingface.co"
     - name: hf.co

--- a/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
+++ b/templates/gke-fqdn-egress-security/terraform-helm/workload/templates/fqdn-network-policy.yaml
@@ -27,10 +27,13 @@ spec:
   - matches:
     - name: anthropic.com
     - name: api.anthropic.com
+    - name: www.anthropic.com
     - pattern: "*.anthropic.com"
     - name: huggingface.co
+    - name: api.huggingface.co
     - pattern: "*.huggingface.co"
     - name: hf.co
+    - name: www.hf.co
     - pattern: "*.hf.co"
     ports:
     - protocol: TCP

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -27,7 +27,6 @@ export KUBECONFIG=$(mktemp)
 trap 'rm -f "$KUBECONFIG"' EXIT
 
 # 1. Cluster Connectivity
-# Ensure we can reach the GKE control plane
 echo "Test 1: Cluster Connectivity..."
 if ! gcloud container clusters get-credentials "${CLUSTER_NAME}" --region "${REGION}" --project "${PROJECT_ID}"; then
   echo "FAILURE: Failed to get cluster credentials."
@@ -66,10 +65,6 @@ echo "Dataplane V2 and FQDN Policy enablement validated."
 
 # 3. FQDNNetworkPolicy Resource Verification
 echo "Test 3: Verifying FQDNNetworkPolicy Resource..."
-
-# NOTE: FQDNNetworkPolicy was promoted to GA in GKE 1.35. 
-# This template uses v1alpha1 as the primary API version.
-# Wait for the CRD to be available (it can take time for GKE to install it after feature enablement)
 echo "Waiting for FQDNNetworkPolicy CRD to be available..."
 CRD_FOUND=false
 for i in {1..30}; do
@@ -90,8 +85,6 @@ if [[ "$CRD_FOUND" == "false" ]]; then
   exit 1
 fi
 
-# The policy should have been installed by the primary deployment phase (Helm or KCC).
-# We verify its existence here.
 if ! kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}"; then
   echo "FAILURE: FQDNNetworkPolicy 'allow-ai-egress' not found in namespace ${NAMESPACE}."
   echo "--- DEBUG INFO ---"
@@ -102,7 +95,6 @@ echo "FQDNNetworkPolicy resource found and verified."
 
 # 4. Wait for Verifier Pod
 echo "Test 4: Waiting for Egress Verifier Pod..."
-# Wait for pod to exist (up to 200 seconds)
 POD_FOUND=false
 for i in {1..20}; do
   if kubectl get pod egress-verifier -n "${NAMESPACE}" > /dev/null 2>&1; then
@@ -133,119 +125,61 @@ echo "Verifier pod is ready."
 # 5. Egress Tests
 echo "Test 5: Running Egress Tests..."
 
-echo "Testing allowed domain: anthropic.com..."
-MAX_RETRIES=12
-SUCCESS=false
-for i in $(seq 1 $MAX_RETRIES); do
-  if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://anthropic.com > /dev/null; then
-    echo "SUCCESS: anthropic.com is reachable (attempt $i)."
-    SUCCESS=true
-    break
-  fi
-  echo "Attempt $i: anthropic.com not reachable yet, retrying in 5s..."
-  sleep 5
-done
+# Helper function to test domain connectivity with retries
+test_domain() {
+  local domain=$1
+  local expected_success=$2
+  local max_retries=12
+  local success=false
 
-if [[ "$SUCCESS" == "false" ]]; then
-  echo "FAILURE: anthropic.com is NOT reachable after $MAX_RETRIES attempts."
-  # Debug: dump policy status and DNS resolution
+  echo "Testing domain: $domain (Expected: $expected_success)..."
+
+  for i in $(seq 1 $max_retries); do
+    if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 "https://$domain" > /dev/null 2>&1; then
+      success=true
+      if [[ "$expected_success" == "true" ]]; then
+        echo "SUCCESS: $domain is reachable (attempt $i)."
+        return 0
+      fi
+    else
+      if [[ "$expected_success" == "false" ]]; then
+        echo "SUCCESS: $domain is blocked as expected (attempt $i)."
+        return 0
+      fi
+    fi
+    
+    if [[ "$expected_success" == "true" ]]; then
+      echo "Attempt $i: $domain not reachable yet, retrying in 5s..."
+    else
+      echo "Attempt $i: $domain still reachable, retrying in 5s (waiting for policy propagation)..."
+    fi
+    sleep 5
+  done
+
+  if [[ "$expected_success" == "true" ]]; then
+    echo "FAILURE: $domain is NOT reachable after $max_retries attempts."
+  else
+    echo "FAILURE: $domain is reachable, but should be blocked!"
+  fi
+
   echo "--- DEBUG INFO ---"
   kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}" -o yaml || true
+  kubectl get networkpolicies -n "${NAMESPACE}" -o yaml || true
   echo "Checking pod status and labels..."
   kubectl get pod egress-verifier -n "${NAMESPACE}" --show-labels || true
   echo "Attempting a direct curl with verbose output..."
-  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://anthropic.com || echo "kubectl exec failed"
-  exit 1
-fi
+  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 "https://$domain" || echo "kubectl exec failed"
+  return 1
+}
 
-echo "Testing allowed domain: api.anthropic.com..."
-# Dataplane V2 FQDN policies sometimes need a few seconds to learn the IP from the first DNS response.
-# We use a retry loop to account for this.
-MAX_RETRIES=12
-SUCCESS=false
-for i in $(seq 1 $MAX_RETRIES); do
-  if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://api.anthropic.com > /dev/null; then
-    echo "SUCCESS: api.anthropic.com is reachable (attempt $i)."
-    SUCCESS=true
-    break
-  fi
-  echo "Attempt $i: api.anthropic.com not reachable yet, retrying in 5s..."
-  sleep 5
-done
+# Test Allowed Domains
+test_domain "anthropic.com" "true"
+test_domain "api.anthropic.com" "true"
+test_domain "huggingface.co" "true"
+test_domain "api.huggingface.co" "true" # Test wildcard *.huggingface.co
+test_domain "hf.co" "true"
 
-if [[ "$SUCCESS" == "false" ]]; then
-  echo "FAILURE: api.anthropic.com is NOT reachable after $MAX_RETRIES attempts."
-  # Debug: dump policy status and DNS resolution
-  echo "--- DEBUG INFO ---"
-  kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}" -o yaml || true
-  echo "Checking pod status and labels..."
-  kubectl get pod egress-verifier -n "${NAMESPACE}" --show-labels || true
-  echo "Attempting a direct curl with verbose output..."
-  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://api.anthropic.com || echo "kubectl exec failed"
-  exit 1
-fi
-
-echo "Testing allowed domain: huggingface.co..."
-SUCCESS=false
-for i in $(seq 1 $MAX_RETRIES); do
-  if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://huggingface.co > /dev/null; then
-    echo "SUCCESS: huggingface.co is reachable (attempt $i)."
-    SUCCESS=true
-    break
-  fi
-  echo "Attempt $i: huggingface.co not reachable yet, retrying in 5s..."
-  sleep 5
-done
-
-if [[ "$SUCCESS" == "false" ]]; then
-  echo "FAILURE: huggingface.co is NOT reachable after $MAX_RETRIES attempts."
-  # Debug: dump policy status and DNS resolution
-  echo "--- DEBUG INFO ---"
-  kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}" -o yaml || true
-  echo "Checking pod status and labels..."
-  kubectl get pod egress-verifier -n "${NAMESPACE}" --show-labels || true
-  echo "Attempting a direct curl with verbose output..."
-  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://huggingface.co || echo "kubectl exec failed"
-  exit 1
-fi
-
-echo "Testing allowed domain: hf.co..."
-SUCCESS=false
-for i in $(seq 1 $MAX_RETRIES); do
-  if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://hf.co > /dev/null; then
-    echo "SUCCESS: hf.co is reachable (attempt $i)."
-    SUCCESS=true
-    break
-  fi
-  echo "Attempt $i: hf.co not reachable yet, retrying in 5s..."
-  sleep 5
-done
-
-if [[ "$SUCCESS" == "false" ]]; then
-  echo "FAILURE: hf.co is NOT reachable after $MAX_RETRIES attempts."
-  # Debug: dump policy status and DNS resolution
-  echo "--- DEBUG INFO ---"
-  kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}" -o yaml || true
-  echo "Checking pod status and labels..."
-  kubectl get pod egress-verifier -n "${NAMESPACE}" --show-labels || true
-  echo "Attempting a direct curl with verbose output..."
-  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://hf.co || echo "kubectl exec failed"
-  exit 1
-fi
-
-echo "Testing blocked domain: google.com..."
-if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://google.com > /dev/null 2>&1; then
-  echo "FAILURE: google.com is reachable, but should be blocked!"
-  echo "--- DEBUG INFO ---"
-  echo "The Default Deny NetworkPolicy or FQDNNetworkPolicy is not working as expected."
-  echo "Current NetworkPolicies:"
-  kubectl get networkpolicies -n "${NAMESPACE}" || true
-  kubectl get fqdnnetworkpolicies.networking.gke.io -n "${NAMESPACE}" || true
-  echo "Testing connectivity to google.com with verbose output:"
-  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://google.com || true
-  exit 1
-else
-  echo "SUCCESS: google.com is blocked as expected."
-fi
+# Test Blocked Domains
+test_domain "google.com" "false"
 
 echo "All GKE FQDN Network Policy Validation Tests passed successfully!"

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -174,6 +174,7 @@ test_domain() {
 
 # Test Allowed Domains
 test_domain "anthropic.com" "true"
+test_domain "www.anthropic.com" "true" # Test wildcard *.anthropic.com
 test_domain "api.anthropic.com" "true"
 test_domain "huggingface.co" "true"
 test_domain "api.huggingface.co" "true" # Test wildcard *.huggingface.co

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -109,6 +109,13 @@ done
 
 if [[ "$SUCCESS" == "false" ]]; then
   echo "FAILURE: anthropic.com is NOT reachable after $MAX_RETRIES attempts."
+  # Debug: dump policy status and DNS resolution
+  echo "--- DEBUG INFO ---"
+  kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}" -o yaml || true
+  echo "Checking pod status and labels..."
+  kubectl get pod egress-verifier -n "${NAMESPACE}" --show-labels || true
+  echo "Attempting a direct curl with verbose output..."
+  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://anthropic.com || echo "kubectl exec failed"
   exit 1
 fi
 
@@ -153,6 +160,13 @@ done
 
 if [[ "$SUCCESS" == "false" ]]; then
   echo "FAILURE: huggingface.co is NOT reachable after $MAX_RETRIES attempts."
+  # Debug: dump policy status and DNS resolution
+  echo "--- DEBUG INFO ---"
+  kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}" -o yaml || true
+  echo "Checking pod status and labels..."
+  kubectl get pod egress-verifier -n "${NAMESPACE}" --show-labels || true
+  echo "Attempting a direct curl with verbose output..."
+  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://huggingface.co || echo "kubectl exec failed"
   exit 1
 fi
 
@@ -170,6 +184,13 @@ done
 
 if [[ "$SUCCESS" == "false" ]]; then
   echo "FAILURE: hf.co is NOT reachable after $MAX_RETRIES attempts."
+  # Debug: dump policy status and DNS resolution
+  echo "--- DEBUG INFO ---"
+  kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}" -o yaml || true
+  echo "Checking pod status and labels..."
+  kubectl get pod egress-verifier -n "${NAMESPACE}" --show-labels || true
+  echo "Attempting a direct curl with verbose output..."
+  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://hf.co || echo "kubectl exec failed"
   exit 1
 fi
 

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -94,6 +94,24 @@ echo "Verifier pod is ready."
 # 5. Egress Tests
 echo "Test 5: Running Egress Tests..."
 
+echo "Testing allowed domain: anthropic.com..."
+MAX_RETRIES=12
+SUCCESS=false
+for i in $(seq 1 $MAX_RETRIES); do
+  if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://anthropic.com > /dev/null; then
+    echo "SUCCESS: anthropic.com is reachable (attempt $i)."
+    SUCCESS=true
+    break
+  fi
+  echo "Attempt $i: anthropic.com not reachable yet, retrying in 5s..."
+  sleep 5
+done
+
+if [[ "$SUCCESS" == "false" ]]; then
+  echo "FAILURE: anthropic.com is NOT reachable after $MAX_RETRIES attempts."
+  exit 1
+fi
+
 echo "Testing allowed domain: api.anthropic.com..."
 # Dataplane V2 FQDN policies sometimes need a few seconds to learn the IP from the first DNS response.
 # We use a retry loop to account for this.

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -177,6 +177,7 @@ test_domain "anthropic.com" "true"
 test_domain "www.anthropic.com" "true" # Test wildcard *.anthropic.com
 test_domain "api.anthropic.com" "true"
 test_domain "huggingface.co" "true"
+test_domain "www.huggingface.co" "true"
 test_domain "api.huggingface.co" "true" # Test wildcard *.huggingface.co
 test_domain "hf.co" "true"
 test_domain "www.hf.co" "true" # Test wildcard *.hf.co

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -178,7 +178,6 @@ test_domain "www.anthropic.com" "true" # Test wildcard *.anthropic.com
 test_domain "api.anthropic.com" "true"
 test_domain "huggingface.co" "true"
 test_domain "www.huggingface.co" "true"
-test_domain "api.huggingface.co" "true" # Test wildcard *.huggingface.co
 test_domain "hf.co" "true"
 test_domain "www.hf.co" "true" # Test wildcard *.hf.co
 

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -178,6 +178,7 @@ test_domain "api.anthropic.com" "true"
 test_domain "huggingface.co" "true"
 test_domain "api.huggingface.co" "true" # Test wildcard *.huggingface.co
 test_domain "hf.co" "true"
+test_domain "www.hf.co" "true" # Test wildcard *.hf.co
 
 # Test Blocked Domains
 test_domain "google.com" "false"

--- a/templates/gke-fqdn-egress-security/validate.sh
+++ b/templates/gke-fqdn-egress-security/validate.sh
@@ -29,8 +29,17 @@ trap 'rm -f "$KUBECONFIG"' EXIT
 # 1. Cluster Connectivity
 # Ensure we can reach the GKE control plane
 echo "Test 1: Cluster Connectivity..."
-gcloud container clusters get-credentials "${CLUSTER_NAME}" --region "${REGION}" --project "${PROJECT_ID}"
-kubectl cluster-info
+if ! gcloud container clusters get-credentials "${CLUSTER_NAME}" --region "${REGION}" --project "${PROJECT_ID}"; then
+  echo "FAILURE: Failed to get cluster credentials."
+  exit 1
+fi
+
+if ! kubectl cluster-info; then
+  echo "FAILURE: Cannot reach cluster API server."
+  echo "--- DEBUG INFO ---"
+  gcloud container clusters describe "${CLUSTER_NAME}" --region "${REGION}" --project "${PROJECT_ID}" --format="value(status,statusMessage)" || true
+  exit 1
+fi
 echo "Connectivity passed."
 
 # 2. Dataplane V2 and FQDN Policy Enablement
@@ -40,11 +49,17 @@ DATAPATH=$(echo "${CLUSTER_DESC}" | jq -r '.networkConfig.datapathProvider')
 FQDN_ENABLED=$(echo "${CLUSTER_DESC}" | jq -r '.networkConfig.enableFqdnNetworkPolicy')
 
 if [[ "$DATAPATH" != "ADVANCED_DATAPATH" ]]; then
-  echo "Dataplane V2 check failed! Provider: $DATAPATH"
+  echo "FAILURE: Dataplane V2 check failed! Provider: $DATAPATH"
+  echo "--- DEBUG INFO ---"
+  echo "Dataplane V2 (ADVANCED_DATAPATH) is required for FQDN Network Policies."
+  echo "Full Network Config:"
+  echo "${CLUSTER_DESC}" | jq '.networkConfig'
   exit 1
 fi
 if [[ "$FQDN_ENABLED" != "true" ]]; then
-  echo "FQDN Network Policy check failed! Enabled: $FQDN_ENABLED"
+  echo "FAILURE: FQDN Network Policy check failed! Enabled: $FQDN_ENABLED"
+  echo "--- DEBUG INFO ---"
+  echo "The enableFqdnNetworkPolicy flag must be set to true."
   exit 1
 fi
 echo "Dataplane V2 and FQDN Policy enablement validated."
@@ -56,18 +71,33 @@ echo "Test 3: Verifying FQDNNetworkPolicy Resource..."
 # This template uses v1alpha1 as the primary API version.
 # Wait for the CRD to be available (it can take time for GKE to install it after feature enablement)
 echo "Waiting for FQDNNetworkPolicy CRD to be available..."
+CRD_FOUND=false
 for i in {1..30}; do
   if kubectl get crd fqdnnetworkpolicies.networking.gke.io > /dev/null 2>&1; then
     echo "CRD found!"
+    CRD_FOUND=true
     break
   fi
   echo "Still waiting for CRD (attempt $i/30)..."
   sleep 10
 done
 
+if [[ "$CRD_FOUND" == "false" ]]; then
+  echo "FAILURE: FQDNNetworkPolicy CRD not found after 5 minutes."
+  echo "--- DEBUG INFO ---"
+  kubectl get crd | grep networking.gke.io || true
+  echo "Check if GKE Enterprise is enabled and the cluster is registered to a fleet."
+  exit 1
+fi
+
 # The policy should have been installed by the primary deployment phase (Helm or KCC).
 # We verify its existence here.
-kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}"
+if ! kubectl get fqdnnetworkpolicies.networking.gke.io allow-ai-egress -n "${NAMESPACE}"; then
+  echo "FAILURE: FQDNNetworkPolicy 'allow-ai-egress' not found in namespace ${NAMESPACE}."
+  echo "--- DEBUG INFO ---"
+  kubectl get fqdnnetworkpolicies.networking.gke.io -A || true
+  exit 1
+fi
 echo "FQDNNetworkPolicy resource found and verified."
 
 # 4. Wait for Verifier Pod
@@ -85,10 +115,19 @@ done
 
 if [[ "$POD_FOUND" == "false" ]]; then
   echo "FAILURE: egress-verifier pod was never created!"
+  echo "--- DEBUG INFO ---"
+  kubectl get pods -n "${NAMESPACE}" || true
+  kubectl get events -n "${NAMESPACE}" --sort-by='.lastTimestamp' | tail -n 20 || true
   exit 1
 fi
 
-kubectl wait --for=condition=Ready pod/egress-verifier -n "${NAMESPACE}" --timeout=5m
+if ! kubectl wait --for=condition=Ready pod/egress-verifier -n "${NAMESPACE}" --timeout=5m; then
+  echo "FAILURE: egress-verifier pod failed to become ready."
+  echo "--- DEBUG INFO ---"
+  kubectl describe pod egress-verifier -n "${NAMESPACE}" || true
+  kubectl logs egress-verifier -n "${NAMESPACE}" || true
+  exit 1
+fi
 echo "Verifier pod is ready."
 
 # 5. Egress Tests
@@ -197,6 +236,13 @@ fi
 echo "Testing blocked domain: google.com..."
 if kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -sL -4 --connect-timeout 10 https://google.com > /dev/null 2>&1; then
   echo "FAILURE: google.com is reachable, but should be blocked!"
+  echo "--- DEBUG INFO ---"
+  echo "The Default Deny NetworkPolicy or FQDNNetworkPolicy is not working as expected."
+  echo "Current NetworkPolicies:"
+  kubectl get networkpolicies -n "${NAMESPACE}" || true
+  kubectl get fqdnnetworkpolicies.networking.gke.io -n "${NAMESPACE}" || true
+  echo "Testing connectivity to google.com with verbose output:"
+  kubectl exec egress-verifier -n "${NAMESPACE}" -- curl -v -4 --connect-timeout 10 https://google.com || true
   exit 1
 else
   echo "SUCCESS: google.com is blocked as expected."

--- a/templates/gke-fqdn-egress-security/verification_plan.md
+++ b/templates/gke-fqdn-egress-security/verification_plan.md
@@ -18,7 +18,7 @@ This plan outlines the steps to verify the implementation of GKE FQDN Network Po
 2.  **FQDN Allow-list:**
     -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `huggingface.co`, and `hf.co`.
     -   Verify `curl https://anthropic.com` and `curl https://api.anthropic.com` return successful responses (not a connection timeout).
-    -   Verify `curl https://huggingface.co` and `curl https://hf.co` succeed.
+    -   Verify `curl https://huggingface.co`, `curl https://api.huggingface.co`, and `curl https://hf.co` succeed.
     -   Verify `curl https://google.com` is actively blocked by the CNI.
 
 ## Automated Validation

--- a/templates/gke-fqdn-egress-security/verification_plan.md
+++ b/templates/gke-fqdn-egress-security/verification_plan.md
@@ -16,9 +16,9 @@ This plan outlines the steps to verify the implementation of GKE FQDN Network Po
     -   Apply the `NetworkPolicy` that denies all egress for pods labeled `app: egress-test`.
     -   Verify that without any other policies, all external `curl` commands fail.
 2.  **FQDN Allow-list:**
-    -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `www.anthropic.com`, `*.anthropic.com`, `huggingface.co`, `api.huggingface.co`, `*.huggingface.co`, `hf.co`, `www.hf.co`, and `*.hf.co`.
+    -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `www.anthropic.com`, `*.anthropic.com`, `huggingface.co`, `api.huggingface.co`, `www.huggingface.co`, `*.huggingface.co`, `hf.co`, `www.hf.co`, and `*.hf.co`.
     -   Verify `curl https://anthropic.com`, `curl https://www.anthropic.com`, and `curl https://api.anthropic.com` return successful responses (not a connection timeout).
-    -   Verify `curl https://huggingface.co`, `curl https://api.huggingface.co`, `curl https://hf.co`, and `curl https://www.hf.co` succeed.
+    -   Verify `curl https://huggingface.co`, `curl https://www.huggingface.co`, `curl https://api.huggingface.co`, `curl https://hf.co`, and `curl https://www.hf.co` succeed.
     -   Verify `curl https://google.com` is actively blocked by the CNI.
 
 ## Automated Validation

--- a/templates/gke-fqdn-egress-security/verification_plan.md
+++ b/templates/gke-fqdn-egress-security/verification_plan.md
@@ -18,7 +18,7 @@ This plan outlines the steps to verify the implementation of GKE FQDN Network Po
 2.  **FQDN Allow-list:**
     -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `huggingface.co`, and `hf.co`.
     -   Verify `curl https://anthropic.com` and `curl https://api.anthropic.com` return successful responses (not a connection timeout).
-    -   Verify `curl https://huggingface.co`, `curl https://api.huggingface.co`, and `curl https://hf.co` succeed.
+    -   Verify `curl https://huggingface.co`, `curl https://api.huggingface.co`, `curl https://hf.co`, and `curl https://www.hf.co` succeed.
     -   Verify `curl https://google.com` is actively blocked by the CNI.
 
 ## Automated Validation

--- a/templates/gke-fqdn-egress-security/verification_plan.md
+++ b/templates/gke-fqdn-egress-security/verification_plan.md
@@ -16,7 +16,7 @@ This plan outlines the steps to verify the implementation of GKE FQDN Network Po
     -   Apply the `NetworkPolicy` that denies all egress for pods labeled `app: egress-test`.
     -   Verify that without any other policies, all external `curl` commands fail.
 2.  **FQDN Allow-list:**
-    -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `huggingface.co`, and `hf.co`.
+    -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `*.anthropic.com`, `huggingface.co`, `*.huggingface.co`, `hf.co`, and `*.hf.co`.
     -   Verify `curl https://anthropic.com`, `curl https://www.anthropic.com`, and `curl https://api.anthropic.com` return successful responses (not a connection timeout).
     -   Verify `curl https://huggingface.co`, `curl https://api.huggingface.co`, `curl https://hf.co`, and `curl https://www.hf.co` succeed.
     -   Verify `curl https://google.com` is actively blocked by the CNI.

--- a/templates/gke-fqdn-egress-security/verification_plan.md
+++ b/templates/gke-fqdn-egress-security/verification_plan.md
@@ -16,9 +16,9 @@ This plan outlines the steps to verify the implementation of GKE FQDN Network Po
     -   Apply the `NetworkPolicy` that denies all egress for pods labeled `app: egress-test`.
     -   Verify that without any other policies, all external `curl` commands fail.
 2.  **FQDN Allow-list:**
-    -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `www.anthropic.com`, `*.anthropic.com`, `huggingface.co`, `api.huggingface.co`, `www.huggingface.co`, `*.huggingface.co`, `hf.co`, `www.hf.co`, and `*.hf.co`.
+    -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `www.anthropic.com`, `*.anthropic.com`, `huggingface.co`, `www.huggingface.co`, `*.huggingface.co`, `hf.co`, `www.hf.co`, and `*.hf.co`.
     -   Verify `curl https://anthropic.com`, `curl https://www.anthropic.com`, and `curl https://api.anthropic.com` return successful responses (not a connection timeout).
-    -   Verify `curl https://huggingface.co`, `curl https://www.huggingface.co`, `curl https://api.huggingface.co`, `curl https://hf.co`, and `curl https://www.hf.co` succeed.
+    -   Verify `curl https://huggingface.co`, `curl https://www.huggingface.co`, `curl https://hf.co`, and `curl https://www.hf.co` succeed.
     -   Verify `curl https://google.com` is actively blocked by the CNI.
 
 ## Automated Validation

--- a/templates/gke-fqdn-egress-security/verification_plan.md
+++ b/templates/gke-fqdn-egress-security/verification_plan.md
@@ -16,9 +16,9 @@ This plan outlines the steps to verify the implementation of GKE FQDN Network Po
     -   Apply the `NetworkPolicy` that denies all egress for pods labeled `app: egress-test`.
     -   Verify that without any other policies, all external `curl` commands fail.
 2.  **FQDN Allow-list:**
-    -   Apply the `FQDNNetworkPolicy` allowing `api.anthropic.com` and `huggingface.co`.
-    -   Verify `curl https://api.anthropic.com` returns a successful response (likely a 401 or similar from the API, but not a connection timeout).
-    -   Verify `curl https://huggingface.co` succeeds.
+    -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `huggingface.co`, and `hf.co`.
+    -   Verify `curl https://anthropic.com` and `curl https://api.anthropic.com` return successful responses (not a connection timeout).
+    -   Verify `curl https://huggingface.co` and `curl https://hf.co` succeed.
     -   Verify `curl https://google.com` is actively blocked by the CNI.
 
 ## Automated Validation

--- a/templates/gke-fqdn-egress-security/verification_plan.md
+++ b/templates/gke-fqdn-egress-security/verification_plan.md
@@ -16,7 +16,7 @@ This plan outlines the steps to verify the implementation of GKE FQDN Network Po
     -   Apply the `NetworkPolicy` that denies all egress for pods labeled `app: egress-test`.
     -   Verify that without any other policies, all external `curl` commands fail.
 2.  **FQDN Allow-list:**
-    -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `*.anthropic.com`, `huggingface.co`, `*.huggingface.co`, `hf.co`, and `*.hf.co`.
+    -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `www.anthropic.com`, `*.anthropic.com`, `huggingface.co`, `api.huggingface.co`, `*.huggingface.co`, `hf.co`, `www.hf.co`, and `*.hf.co`.
     -   Verify `curl https://anthropic.com`, `curl https://www.anthropic.com`, and `curl https://api.anthropic.com` return successful responses (not a connection timeout).
     -   Verify `curl https://huggingface.co`, `curl https://api.huggingface.co`, `curl https://hf.co`, and `curl https://www.hf.co` succeed.
     -   Verify `curl https://google.com` is actively blocked by the CNI.

--- a/templates/gke-fqdn-egress-security/verification_plan.md
+++ b/templates/gke-fqdn-egress-security/verification_plan.md
@@ -17,7 +17,7 @@ This plan outlines the steps to verify the implementation of GKE FQDN Network Po
     -   Verify that without any other policies, all external `curl` commands fail.
 2.  **FQDN Allow-list:**
     -   Apply the `FQDNNetworkPolicy` allowing `anthropic.com`, `api.anthropic.com`, `huggingface.co`, and `hf.co`.
-    -   Verify `curl https://anthropic.com` and `curl https://api.anthropic.com` return successful responses (not a connection timeout).
+    -   Verify `curl https://anthropic.com`, `curl https://www.anthropic.com`, and `curl https://api.anthropic.com` return successful responses (not a connection timeout).
     -   Verify `curl https://huggingface.co`, `curl https://api.huggingface.co`, `curl https://hf.co`, and `curl https://www.hf.co` succeed.
     -   Verify `curl https://google.com` is actively blocked by the CNI.
 


### PR DESCRIPTION
This PR updates the README for the `gke-fqdn-egress-security` template to include detailed instructions for the Config Connector (KCC) deployment path and ensures complete, consistent domain coverage for external AI services.

Key changes:
- **Consistent Domain Coverage:** Explicitly handled 7 domains (`anthropic.com`, `api.anthropic.com`, `www.anthropic.com`, `huggingface.co`, `www.huggingface.co`, `hf.co`, and `www.hf.co`) and their respective wildcard patterns across manifests, README, and validation tests.
- **Improved Validation:** Refactored `validate.sh` with robust retry logic and extended debug info for FQDN policy propagation.
- **Enhanced Documentation:** Expanded KCC 'Deploy Workload' section with explicit `kubectl` commands and added notes on CRD propagation and Dataplane V2 initial latency.
- **Structural Integrity:** Ensured full alignment between Terraform/Helm and KCC deployment paths.

Fixes #51

*(This PR description was updated by Overseer)*