### PR TITLE
fix: add iam.serviceAccountAdmin role to forge-builder SA

### DIFF
--- a/agent-infra/main.tf
+++ b/agent-infra/main.tf
@@ -101,6 +101,7 @@ locals {
     "roles/gkehub.admin",
     "roles/resourcemanager.projectIamAdmin",
     "roles/secretmanager.secretAccessor",
+    "roles/iam.serviceAccountAdmin",
   ]
 }
 


### PR DESCRIPTION
This PR resolves #99 by adding the necessary IAM role to the CI service account, allowing it to create dedicated node service accounts for templates that require them. This is a foundational fix for multiple templates currently blocked in CI (e.g., #76).