### PR TITLE
[CI-BUG] Increase KCC Validation Timeout to Match Wait Script

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -203,7 +203,7 @@ jobs:
           BASE_NAME=$(basename "$TEMPLATE")
           find "${TEMPLATE}"/config-connector* -type f -name "*.yaml" -exec sed -i "s/${BASE_NAME}/${BASE_NAME}-${UID_SUFFIX}/g" {} +
           kubectl apply -n "$KCC_NAMESPACE" -f "${TEMPLATE}/config-connector/"
-          kubectl wait -n "$KCC_NAMESPACE" --for=condition=Ready --all --timeout=3600s -f "${TEMPLATE}/config-connector/"
+          kubectl wait -n "$KCC_NAMESPACE" --for=condition=Ready --all --timeout=5400s -f "${TEMPLATE}/config-connector/"
           KCC_DURATION=$(( $(date -u +%s) - KCC_START ))
           echo "kcc_duration=${KCC_DURATION}" >> "$GITHUB_OUTPUT"
       - name: KCC Teardown

--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -242,7 +242,7 @@ jobs:
     name: KCC (${{ matrix.template }})
     needs: [detect-changes, lint, pre-cleanup]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 100
     strategy:
       fail-fast: false
       matrix:
@@ -268,7 +268,7 @@ jobs:
           BASE_NAME=$(basename "$TEMPLATE")
           find "${TEMPLATE}"/config-connector* -type f -name "*.yaml" -exec sed -i "s/${BASE_NAME}/${BASE_NAME}-${UID_SUFFIX}/g" {} +
           kubectl apply -n "$KCC_NAMESPACE" -f "${TEMPLATE}/config-connector/"
-          kubectl wait -n "$KCC_NAMESPACE" --for=condition=Ready --all --timeout=3600s -f "${TEMPLATE}/config-connector/"
+          kubectl wait -n "$KCC_NAMESPACE" --for=condition=Ready --all --timeout=5400s -f "${TEMPLATE}/config-connector/"
       - name: Teardown KCC
         if: always()
         run: |

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ flowchart LR
 
     subgraph push ["━━━  Push to main  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"]
         direction LR
-        VTH(["🏗️ validate-tf-helm\nper template · 90 min timeout\nTF apply → verify cluster\nRUNNING → TF destroy\nSaves results artifact"])
-        VKCC(["☸️ validate-kcc\nper template · 60 min timeout\nFresh runner — KCC cluster\ncreds from the start\nKCC apply → wait Ready\n→ delete\nSaves results artifact"])
+        VTH(["🏗️ validate-tf-helm\nper template · 120 min timeout\nTF apply → verify cluster\nRUNNING → TF destroy\nSaves results artifact"])
+        VKCC(["☸️ validate-kcc\nper template · 120 min timeout\nFresh runner — KCC cluster\ncreds from the start\nKCC apply → wait Ready\n→ delete\nSaves results artifact"])
         PUB(["📋 publish-validated\nper template\nAccumulate agent metrics\nUpdate README + .validated\n.agent-metrics-cumulative\ngit push [skip ci]"])
     end
 


### PR DESCRIPTION
The KCC validation job in `ci-pr-validation.yml` had a 60-minute timeout, but some resources can take up to 90 minutes to become ready. This caused the job to be killed by GitHub Actions before completion.

This PR increases the `timeout-minutes` to 100 and the `kubectl wait` timeout to 90 minutes (5400s) to accommodate these longer provisioning times. It also updates the documentation in `README.md` to reflect the actual timeouts used in the post-merge validation.

Fixes #101

Generated by **Overseer** (powered by the gemini-3-flash-preview model).