### PR TITLE
ci: fix terraform apply failure masking

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -116,7 +116,13 @@ jobs:
           for REGION in "${REGIONS[@]}"; do
             echo "Attempting deployment in $REGION..."
             export TF_VAR_region="$REGION"
-            if terraform apply -auto-approve -input=false 2>&1 | tee /tmp/tf.log; then
+            
+            set +e
+            terraform apply -auto-approve -input=false 2>&1 | tee /tmp/tf.log
+            TF_EXIT=${PIPESTATUS[0]}
+            set -e
+
+            if [ "$TF_EXIT" -eq 0 ]; then
               SUCCESS=true; break
             else
               if grep -iE "RESOURCE_EXHAUSTED|ZONE_RESOURCE_POOL_EXHAUSTED|QUOTA_EXCEEDED|stockout" /tmp/tf.log; then

--- a/.github/workflows/ci-pr-validation.yml
+++ b/.github/workflows/ci-pr-validation.yml
@@ -152,7 +152,13 @@ jobs:
           for REGION in "${REGIONS[@]}"; do
             echo "Attempting deployment in $REGION..."
             export TF_VAR_region="$REGION"
-            if terraform apply -auto-approve -input=false 2>&1 | tee /tmp/tf.log; then
+            
+            set +e
+            terraform apply -auto-approve -input=false 2>&1 | tee /tmp/tf.log
+            TF_EXIT=${PIPESTATUS[0]}
+            set -e
+
+            if [ "$TF_EXIT" -eq 0 ]; then
               SUCCESS=true; break
             else
               echo "Deployment in $REGION failed. Checking for stockout..."


### PR DESCRIPTION
Fixes #106

This PR fixes a bug where `terraform apply` failures were being masked by the default bash pipeline behavior when piping the output to `tee /tmp/tf.log`.

Changes made:
- Temporarily disabled `set -e` (`set +e`) right before the command pipeline.
- Captured the explicit exit code of the `terraform apply` command using `${PIPESTATUS[0]}`.
- Re-enabled `set -e` (`set -e`) after capturing the code.
- Replaced the direct `if` condition on the pipeline with an `if [ "$TF_EXIT" -eq 0 ]` check.

This fix was applied to both `ci-pr-validation.yml` and `ci-post-merge.yml`.

*(This PR was generated by **Overseer** (powered by the gemini-3.1-pro-preview model))*
