### PR TITLE
[EPIC] Adopt 'Epic + Sub-issues' Model and Split CI Validation Workflow

### DIFF
--- a/.github/workflows/validate-kcc.yml
+++ b/.github/workflows/validate-kcc.yml
@@ -1,0 +1,189 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: KCC PR Validation
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'templates/**/config-connector/**'
+      - 'templates/**/config-connector-workload/**'
+      - '.github/workflows/validate-kcc.yml'
+      - '.github/actions/**'
+      - 'agent-infra/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+  actions: write
+
+env:
+  PROJECT_ID: gca-gke-2025
+  KCC_CLUSTER: krmapihost-kcc-instance
+  KCC_REGION: us-central1
+  KCC_NAMESPACE: forge-management
+  WIF_PROVIDER: projects/764460891170/locations/global/workloadIdentityPools/github-actions/providers/github
+  WIF_SERVICE_ACCOUNT: forge-builder@gca-gke-2025.iam.gserviceaccount.com
+  TF_STATE_BUCKET: gke-gca-2025-forge-tf-state
+  USE_GKE_GCLOUD_AUTH_PLUGIN: "True"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  TF_VAR_project_id: gca-gke-2025
+  TF_VAR_service_account: forge-builder@gca-gke-2025.iam.gserviceaccount.com
+
+jobs:
+  detect-changes:
+    name: Detect Changed Templates
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+    outputs:
+      templates: ${{ steps.detect.outputs.templates }}
+      tf_templates: ${{ steps.detect.outputs.tf_templates }}
+      kcc_templates: ${{ steps.detect.outputs.kcc_templates }}
+      has_templates: ${{ steps.detect.outputs.has_templates }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: detect
+        uses: ./.github/actions/detect-changes
+      - name: Remove repo-agent Label on Start
+        run: gh pr edit "${{ github.event.number }}" --remove-label "repo-agent" || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  lint:
+    name: Lint (${{ matrix.template }})
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.has_templates == 'true'
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        template: ${{ fromJson(needs.detect-changes.outputs.templates) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+      - name: Set up Helm
+        run: curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+      - name: Run Thorough Linting
+        run: |
+          chmod +x agent-infra/local-lint.sh
+          ./agent-infra/local-lint.sh "${{ matrix.template }}"
+      - name: Actionlint
+        run: |
+          if [ -f "./actionlint" ]; then
+            ./actionlint
+          fi
+
+  pre-cleanup:
+    name: Quota Cleanup
+    needs: detect-changes
+    runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.has_templates == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+      - name: Run Cleanup Script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x agent-infra/cleanup-resources.sh
+          ./agent-infra/cleanup-resources.sh
+
+
+  kcc-validation:
+    name: KCC (${{ matrix.template }})
+    needs: [detect-changes, lint, pre-cleanup]
+    runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.kcc_templates != '[]' && needs.detect-changes.outputs.kcc_templates != ''
+    timeout-minutes: 100
+    strategy:
+      fail-fast: false
+      matrix:
+        template: ${{ fromJson(needs.detect-changes.outputs.kcc_templates) }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Auth and Setup GKE
+        uses: ./.github/actions/gcp-gke-auth
+        with:
+          wif_provider: ${{ env.WIF_PROVIDER }}
+          wif_service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+      - name: Get KCC cluster credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ env.KCC_CLUSTER }}
+          location: ${{ env.KCC_REGION }}
+          project_id: ${{ env.PROJECT_ID }}
+      - name: Apply and Wait
+        run: |
+          RUN_ID="${{ github.run_id }}"
+          UID_SUFFIX="${RUN_ID: -6}"
+          TEMPLATE="${{ matrix.template }}"
+          BASE_NAME=$(basename "$TEMPLATE")
+          find "${TEMPLATE}"/config-connector* -type f -name "*.yaml" -exec sed -i "s/${BASE_NAME}/${BASE_NAME}-${UID_SUFFIX}/g" {} +
+          kubectl apply -n "$KCC_NAMESPACE" -f "${TEMPLATE}/config-connector/"
+          kubectl wait -n "$KCC_NAMESPACE" --for=condition=Ready --all --timeout=5400s -f "${TEMPLATE}/config-connector/"
+      - name: Teardown KCC
+        if: always()
+        run: |
+          TEMPLATE="${{ matrix.template }}"
+          kubectl delete -n "$KCC_NAMESPACE" -f "${TEMPLATE}/config-connector/" --wait=true --timeout=900s || true
+
+  circuit-breaker:
+    name: Circuit Breaker
+    needs: [kcc-validation]
+    if: always() && (needs.kcc-validation.result == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Retry Count and Label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMENTS=$(gh pr view "${{ github.event.number }}" --json comments -q '.comments[].body')
+          FAIL_COUNT=$(echo "$COMMENTS" | grep -c "Infrastructure failure detected" || echo "0")
+          if [ "$FAIL_COUNT" -ge 3 ]; then
+            gh pr comment "${{ github.event.number }}" --body "🚨 **Circuit Breaker Tripped**: This PR has failed infrastructure validation 3+ times. Stopping automated retries."
+          else
+            gh pr comment "${{ github.event.number }}" --body "⚠️ Infrastructure failure detected (Attempt $((FAIL_COUNT + 1))). Re-adding repo-agent label."
+            gh pr edit "${{ github.event.number }}" --add-label "repo-agent"
+          fi
+
+  cleanup-orphans:
+    name: Cleanup Orphans
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+      - name: Run Cleanup Script
+        run: |
+          chmod +x agent-infra/cleanup-resources.sh
+          ./agent-infra/cleanup-resources.sh

--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: PR Validation
+name: TF PR Validation
 
 on:
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, closed]
     paths:
-      - 'templates/**'
-      - 'agent-infra/**'
-      - '.github/workflows/**'
+      - 'templates/**/terraform-helm/**'
+      - '.github/workflows/validate-tf.yml'
       - '.github/actions/**'
+      - 'agent-infra/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -72,6 +72,7 @@ jobs:
     name: Lint (${{ matrix.template }})
     needs: detect-changes
     runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.has_templates == 'true'
     timeout-minutes: 20
     strategy:
       fail-fast: false
@@ -97,6 +98,7 @@ jobs:
     name: Quota Cleanup
     needs: detect-changes
     runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.has_templates == 'true'
     steps:
       - uses: actions/checkout@v4
       - name: Authenticate to GCP
@@ -115,6 +117,7 @@ jobs:
     name: TF Provision (${{ matrix.template }})
     needs: [detect-changes, lint, pre-cleanup]
     runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.tf_templates != '[]' && needs.detect-changes.outputs.tf_templates != ''
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -171,6 +174,7 @@ jobs:
     name: TF Test (${{ matrix.template }})
     needs: [detect-changes, tf-provision]
     runs-on: ubuntu-latest
+    if: needs.detect-changes.outputs.tf_templates != '[]' && needs.detect-changes.outputs.tf_templates != ''
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -215,7 +219,7 @@ jobs:
   tf-teardown:
     name: TF Teardown (${{ matrix.template }})
     needs: [detect-changes, tf-provision, tf-test]
-    if: always()
+    if: always() && needs.detect-changes.outputs.tf_templates != '[]' && needs.detect-changes.outputs.tf_templates != ''
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -238,47 +242,11 @@ jobs:
             -backend-config="prefix=${{ matrix.template }}-${{ github.run_id }}/terraform-helm"
           terraform destroy -auto-approve -input=false || true
 
-  kcc-validation:
-    name: KCC (${{ matrix.template }})
-    needs: [detect-changes, lint, pre-cleanup]
-    runs-on: ubuntu-latest
-    timeout-minutes: 100
-    strategy:
-      fail-fast: false
-      matrix:
-        template: ${{ fromJson(needs.detect-changes.outputs.kcc_templates) }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Auth and Setup GKE
-        uses: ./.github/actions/gcp-gke-auth
-        with:
-          wif_provider: ${{ env.WIF_PROVIDER }}
-          wif_service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
-      - name: Get KCC cluster credentials
-        uses: google-github-actions/get-gke-credentials@v2
-        with:
-          cluster_name: ${{ env.KCC_CLUSTER }}
-          location: ${{ env.KCC_REGION }}
-          project_id: ${{ env.PROJECT_ID }}
-      - name: Apply and Wait
-        run: |
-          RUN_ID="${{ github.run_id }}"
-          UID_SUFFIX="${RUN_ID: -6}"
-          TEMPLATE="${{ matrix.template }}"
-          BASE_NAME=$(basename "$TEMPLATE")
-          find "${TEMPLATE}"/config-connector* -type f -name "*.yaml" -exec sed -i "s/${BASE_NAME}/${BASE_NAME}-${UID_SUFFIX}/g" {} +
-          kubectl apply -n "$KCC_NAMESPACE" -f "${TEMPLATE}/config-connector/"
-          kubectl wait -n "$KCC_NAMESPACE" --for=condition=Ready --all --timeout=5400s -f "${TEMPLATE}/config-connector/"
-      - name: Teardown KCC
-        if: always()
-        run: |
-          TEMPLATE="${{ matrix.template }}"
-          kubectl delete -n "$KCC_NAMESPACE" -f "${TEMPLATE}/config-connector/" --wait=true --timeout=900s || true
 
   circuit-breaker:
     name: Circuit Breaker
-    needs: [tf-provision, tf-test, tf-teardown, kcc-validation]
-    if: always() && (needs.tf-provision.result == 'failure' || needs.tf-test.result == 'failure' || needs.kcc-validation.result == 'failure')
+    needs: [tf-provision, tf-test, tf-teardown]
+    if: always() && (needs.tf-provision.result == 'failure' || needs.tf-test.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Check Retry Count and Label


### PR DESCRIPTION
## Description
Adopts the new "Epic + Sub-issues" development model by splitting the `ci-pr-validation.yml` workflow into two distinct workflows:
* `validate-tf.yml`: Triggered only by changes in Terraform paths (`terraform-helm/`).
* `validate-kcc.yml`: Triggered only by changes in Config Connector paths (`config-connector/` and `config-connector-workload/`).

This ensures faster feedback, reduces CI flakiness, and avoids blocking Terraform development when Config Connector features are unavailable.

Fixes #119

*This PR was generated by **Overseer** (powered by the gemini-3.1-pro-preview model).*
