### PR TITLE
fix: implement Config Connector path for gke-kuberay-kueue-multitenant

### DIFF
--- a/templates/gke-kuberay-kueue-multitenant/README.md
+++ b/templates/gke-kuberay-kueue-multitenant/README.md
@@ -10,6 +10,17 @@ A GKE template demonstrating how to solve the "Noisy Neighbor" problem for share
 - **Kueue Operator** — Cloud-native job queueing and equitable resource sharing.
 - **Workloads** — Two namespaces (`team-a` and `team-b`), each with a Kueue `LocalQueue` linked to a `ClusterQueue` sharing a single GPU `Cohort`. Kueue ensures that if Team A requests excess GPUs, their pods remain in a pending state until Team B finishes their work.
 
+## Prerequisites
+
+- **Google Cloud Project**: You must have a GCP project with billing enabled.
+- **APIs Enabled**: Ensure `compute.googleapis.com` and `container.googleapis.com` are enabled.
+- **IAM Permissions**: You need permissions to create VPCs, Subnets, GKE clusters, and Service Accounts.
+- **Tools**:
+  - `gcloud` CLI installed and authenticated.
+  - `kubectl` installed.
+  - For Terraform: `terraform` CLI installed.
+  - For Config Connector: A management cluster with Config Connector installed and configured to manage resources in your GCP project.
+
 ## Deployment Paths
 
 ### Terraform + Helm (`terraform-helm/`)
@@ -32,7 +43,7 @@ terraform apply -var="project_id=my-project-id" -var="service_account=my-service
     ```
 3.  Wait for the cluster to be ready:
     ```bash
-    kubectl wait --for=condition=Ready containercluster ray-kueue-cluster --timeout=30m
+    kubectl wait --for=condition=Ready containercluster ray-kueue-cluster -n forge-management --timeout=30m
     ```
 4.  Configure `kubectl` and deploy the operators and workloads:
     ```bash

--- a/templates/gke-kuberay-kueue-multitenant/config-connector-workload/workload.yaml
+++ b/templates/gke-kuberay-kueue-multitenant/config-connector-workload/workload.yaml
@@ -1,43 +1,16 @@
-# Copyright 2026 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
----
 apiVersion: v1
 kind: Namespace
 metadata:
   name: team-a
   labels:
-    project: ray-kueue
-    team: team-a
+    kueue.x-k8s.io/queue-name: team-a-queue
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: team-b
   labels:
-    project: ray-kueue
-    team: team-b
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kuberay-operator
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kueue-system
+    kueue.x-k8s.io/queue-name: team-b-queue
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor
@@ -45,58 +18,50 @@ metadata:
   name: default-flavor
 spec:
   nodeLabels:
-    gpu: l4
-  tolerations:
-  - key: "nvidia.com/gpu"
-    operator: "Equal"
-    value: "present"
-    effect: "NoSchedule"
+    gpu: "l4"
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
   name: team-a-cq
 spec:
-  namespaceSelector:
-    matchLabels:
-      team: team-a
-  cohort: ray-cohort
+  cohort: shared-gpus
   resourceGroups:
-  - flavors:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
     - name: default-flavor
       resources:
       - name: "nvidia.com/gpu"
-        nominalQuota: 2
----
-apiVersion: kueue.x-k8s.io/v1beta1
-kind: LocalQueue
-metadata:
-  name: ray-queue
-  namespace: team-a
-spec:
-  clusterQueue: team-a-cq
+        nominalQuota: 1
+        borrowingLimit: 1
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
   name: team-b-cq
 spec:
-  namespaceSelector:
-    matchLabels:
-      team: team-b
-  cohort: ray-cohort
+  cohort: shared-gpus
   resourceGroups:
-  - flavors:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
     - name: default-flavor
       resources:
       - name: "nvidia.com/gpu"
-        nominalQuota: 2
-        borrowingLimit: 2
+        nominalQuota: 1
+        borrowingLimit: 1
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue
 metadata:
-  name: ray-queue
+  name: team-a-queue
+  namespace: team-a
+spec:
+  clusterQueue: team-a-cq
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: team-b-queue
   namespace: team-b
 spec:
   clusterQueue: team-b-cq
@@ -104,10 +69,10 @@ spec:
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  name: ray-team-a
+  name: team-a-raycluster
   namespace: team-a
   labels:
-    kueue.x-k8s.io/queue-name: ray-queue
+    kueue.x-k8s.io/queue-name: team-a-queue
 spec:
   rayVersion: '2.9.0'
   headGroupSpec:
@@ -117,7 +82,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.9.0-py310
+          image: rayproject/ray:2.9.0
           resources:
             limits:
               cpu: "1"
@@ -125,46 +90,36 @@ spec:
             requests:
               cpu: "1"
               memory: "2Gi"
-          ports:
-          - containerPort: 6379
-            name: gcs-server
-          - containerPort: 8265
-            name: dashboard
-          - containerPort: 10001
-            name: client
   workerGroupSpecs:
-  - replicas: 2
+  - groupName: worker-group
+    replicas: 2
     minReplicas: 0
     maxReplicas: 5
-    groupName: gpu-group
     rayStartParams: {}
     template:
       spec:
+        nodeSelector:
+          gpu: "l4"
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.9.0-py310
+          image: rayproject/ray:2.9.0
           resources:
             limits:
-              cpu: "2"
-              memory: "4Gi"
+              cpu: "1"
+              memory: "2Gi"
               nvidia.com/gpu: 1
             requests:
-              cpu: "2"
-              memory: "4Gi"
+              cpu: "1"
+              memory: "2Gi"
               nvidia.com/gpu: 1
-        tolerations:
-        - key: "nvidia.com/gpu"
-          operator: "Equal"
-          value: "present"
-          effect: "NoSchedule"
 ---
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  name: ray-team-b
+  name: team-b-raycluster
   namespace: team-b
   labels:
-    kueue.x-k8s.io/queue-name: ray-queue
+    kueue.x-k8s.io/queue-name: team-b-queue
 spec:
   rayVersion: '2.9.0'
   headGroupSpec:
@@ -174,7 +129,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.9.0-py310
+          image: rayproject/ray:2.9.0
           resources:
             limits:
               cpu: "1"
@@ -182,35 +137,25 @@ spec:
             requests:
               cpu: "1"
               memory: "2Gi"
-          ports:
-          - containerPort: 6379
-            name: gcs-server
-          - containerPort: 8265
-            name: dashboard
-          - containerPort: 10001
-            name: client
   workerGroupSpecs:
-  - replicas: 2
+  - groupName: worker-group
+    replicas: 1
     minReplicas: 0
     maxReplicas: 5
-    groupName: gpu-group
     rayStartParams: {}
     template:
       spec:
+        nodeSelector:
+          gpu: "l4"
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.9.0-py310
+          image: rayproject/ray:2.9.0
           resources:
             limits:
-              cpu: "2"
-              memory: "4Gi"
+              cpu: "1"
+              memory: "2Gi"
               nvidia.com/gpu: 1
             requests:
-              cpu: "2"
-              memory: "4Gi"
+              cpu: "1"
+              memory: "2Gi"
               nvidia.com/gpu: 1
-        tolerations:
-        - key: "nvidia.com/gpu"
-          operator: "Equal"
-          value: "present"
-          effect: "NoSchedule"

--- a/templates/gke-kuberay-kueue-multitenant/config-connector/cluster.yaml
+++ b/templates/gke-kuberay-kueue-multitenant/config-connector/cluster.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: forge-management
   labels:
     project: gcp-template-forge
-    template: ray-kueue
+    template: gke-kuberay-kueue-multitenant
   annotations:
     cnrm.cloud.google.com/project-id: gca-gke-2025
     cnrm.cloud.google.com/remove-default-node-pool: "true"
@@ -40,5 +40,6 @@ spec:
     workloadPool: gca-gke-2025.svc.id.goog
   releaseChannel:
     channel: REGULAR
-  gatewayApiConfig:
-    channel: CHANNEL_STANDARD
+  securityPostureConfig:
+    mode: BASIC
+    vulnerabilityMode: VULNERABILITY_BASIC

--- a/templates/gke-kuberay-kueue-multitenant/config-connector/network.yaml
+++ b/templates/gke-kuberay-kueue-multitenant/config-connector/network.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: forge-management
   labels:
     project: gcp-template-forge
-    template: ray-kueue
+    template: gke-kuberay-kueue-multitenant
   annotations:
     cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
@@ -32,7 +32,7 @@ metadata:
   namespace: forge-management
   labels:
     project: gcp-template-forge
-    template: ray-kueue
+    template: gke-kuberay-kueue-multitenant
   annotations:
     cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
@@ -46,35 +46,3 @@ spec:
       ipCidrRange: 10.4.0.0/14
     - rangeName: services
       ipCidrRange: 10.8.0.0/20
----
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeRouter
-metadata:
-  name: ray-kueue-router
-  namespace: forge-management
-  labels:
-    project: gcp-template-forge
-    template: ray-kueue
-  annotations:
-    cnrm.cloud.google.com/project-id: gca-gke-2025
-spec:
-  networkRef:
-    name: ray-kueue-vpc
-  region: us-central1
----
-apiVersion: compute.cnrm.cloud.google.com/v1beta1
-kind: ComputeRouterNAT
-metadata:
-  name: ray-kueue-nat
-  namespace: forge-management
-  labels:
-    project: gcp-template-forge
-    template: ray-kueue
-  annotations:
-    cnrm.cloud.google.com/project-id: gca-gke-2025
-spec:
-  routerRef:
-    name: ray-kueue-router
-  region: us-central1
-  natIpAllocateOption: AUTO_ONLY
-  sourceSubnetworkIpRangesToNat: ALL_SUBNETWORKS_ALL_IP_RANGES

--- a/templates/gke-kuberay-kueue-multitenant/config-connector/nodepool.yaml
+++ b/templates/gke-kuberay-kueue-multitenant/config-connector/nodepool.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: forge-management
   labels:
     project: gcp-template-forge
-    template: ray-kueue
+    template: gke-kuberay-kueue-multitenant
   annotations:
     cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
@@ -28,19 +28,20 @@ spec:
   location: us-central1
   nodeLocations:
     - us-central1-a
-  nodeCount: 1
+  autoscaling:
+    minNodeCount: 1
+    maxNodeCount: 3
   nodeConfig:
     machineType: e2-standard-4
     diskSizeGb: 50
-    diskType: pd-balanced
-    spot: true
+    diskType: pd-standard
     oauthScopes:
       - https://www.googleapis.com/auth/cloud-platform
     workloadMetadataConfig:
       mode: GKE_METADATA
     labels:
       project: gcp-template-forge
-      template: ray-kueue
+      template: gke-kuberay-kueue-multitenant
 ---
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
@@ -49,7 +50,7 @@ metadata:
   namespace: forge-management
   labels:
     project: gcp-template-forge
-    template: ray-kueue
+    template: gke-kuberay-kueue-multitenant
   annotations:
     cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
@@ -60,11 +61,10 @@ spec:
     - us-central1-a
   autoscaling:
     minNodeCount: 0
-    maxNodeCount: 10
-    locationPolicy: BALANCED
+    maxNodeCount: 5
   nodeConfig:
     machineType: g2-standard-4
-    diskSizeGb: 100
+    diskSizeGb: 50
     diskType: pd-balanced
     spot: true
     guestAccelerator:
@@ -78,9 +78,5 @@ spec:
       mode: GKE_METADATA
     labels:
       project: gcp-template-forge
-      template: ray-kueue
+      template: gke-kuberay-kueue-multitenant
       gpu: l4
-    taint:
-      - key: nvidia.com/gpu
-        value: "present"
-        effect: NO_SCHEDULE


### PR DESCRIPTION
Closes #168. Implements the KCC path to ensure functional parity with the Terraform path for Epic #122.