### PR TITLE
fix: use shortName in KCC resource names to avoid collision

### DIFF
--- a/templates/gke-kuberay-kueue-multitenant/config-connector/cluster.yaml
+++ b/templates/gke-kuberay-kueue-multitenant/config-connector/cluster.yaml
@@ -30,9 +30,9 @@ spec:
     - us-central1-a
   initialNodeCount: 1
   networkRef:
-    name: gke-kuberay-kueue-vpc-kcc
+    name: kuberay-kueue-vpc-kcc
   subnetworkRef:
-    name: gke-kuberay-kueue-subnet-kcc
+    name: kuberay-kueue-sub-kcc
   ipAllocationPolicy:
     clusterSecondaryRangeName: pods
     servicesSecondaryRangeName: services

--- a/templates/gke-kuberay-kueue-multitenant/config-connector/network.yaml
+++ b/templates/gke-kuberay-kueue-multitenant/config-connector/network.yaml
@@ -15,7 +15,7 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:
-  name: gke-kuberay-kueue-vpc-kcc
+  name: kuberay-kueue-vpc-kcc
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -28,7 +28,7 @@ spec:
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSubnetwork
 metadata:
-  name: gke-kuberay-kueue-subnet-kcc
+  name: kuberay-kueue-sub-kcc
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -39,7 +39,7 @@ spec:
   ipCidrRange: 10.0.0.0/20
   region: us-central1
   networkRef:
-    name: gke-kuberay-kueue-vpc-kcc
+    name: kuberay-kueue-vpc-kcc
   privateIpGoogleAccess: true
   secondaryIpRange:
     - rangeName: pods

--- a/templates/gke-kuberay-kueue-multitenant/config-connector/nodepool.yaml
+++ b/templates/gke-kuberay-kueue-multitenant/config-connector/nodepool.yaml
@@ -15,7 +15,7 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
 metadata:
-  name: gke-kuberay-sys-kcc
+  name: kuberay-kueue-sys-kcc
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -46,7 +46,7 @@ spec:
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
 metadata:
-  name: gke-kuberay-gpu-kcc
+  name: kuberay-kueue-gpu-kcc
   namespace: forge-management
   labels:
     project: gcp-template-forge


### PR DESCRIPTION
Follow-up to #186 to prevent KCC name collisions during CI by using the template shortName.