### PR TITLE
[KCC] Template: Multi-Tenant Ray on GKE with Equitable Queuing

### DIFF
--- a/templates/gke-kuberay-kueue-multitenant/README.md
+++ b/templates/gke-kuberay-kueue-multitenant/README.md
@@ -43,11 +43,11 @@ terraform apply -var="project_id=my-project-id" -var="service_account=my-service
     ```
 3.  Wait for the cluster to be ready:
     ```bash
-    kubectl wait --for=condition=Ready containercluster gke-kuberay-kueue-kcc -n forge-management --timeout=30m
+    kubectl wait --for=condition=Ready containercluster gke-kuberay-kueue-multitenant-cluster-kcc -n forge-management --timeout=30m
     ```
 4.  Configure `kubectl` and deploy the operators and workloads:
     ```bash
-    gcloud container clusters get-credentials gke-kuberay-kueue-kcc --region us-central1
+    gcloud container clusters get-credentials gke-kuberay-kueue-multitenant-cluster-kcc --region us-central1
     cd ../config-connector-workload
     kubectl create namespace kuberay-operator
     kubectl create namespace kueue-system

--- a/templates/gke-kuberay-kueue-multitenant/config-connector/cluster.yaml
+++ b/templates/gke-kuberay-kueue-multitenant/config-connector/cluster.yaml
@@ -15,7 +15,7 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerCluster
 metadata:
-  name: gke-kuberay-kueue-kcc
+  name: gke-kuberay-kueue-multitenant-cluster-kcc
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -30,9 +30,9 @@ spec:
     - us-central1-a
   initialNodeCount: 1
   networkRef:
-    name: kuberay-kueue-vpc-kcc
+    name: gke-kuberay-kueue-multitenant-vpc-kcc
   subnetworkRef:
-    name: kuberay-kueue-sub-kcc
+    name: gke-kuberay-kueue-multitenant-sub-kcc
   ipAllocationPolicy:
     clusterSecondaryRangeName: pods
     servicesSecondaryRangeName: services

--- a/templates/gke-kuberay-kueue-multitenant/config-connector/network.yaml
+++ b/templates/gke-kuberay-kueue-multitenant/config-connector/network.yaml
@@ -15,7 +15,7 @@
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeNetwork
 metadata:
-  name: kuberay-kueue-vpc-kcc
+  name: gke-kuberay-kueue-multitenant-vpc-kcc
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -28,7 +28,7 @@ spec:
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeSubnetwork
 metadata:
-  name: kuberay-kueue-sub-kcc
+  name: gke-kuberay-kueue-multitenant-sub-kcc
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -39,7 +39,7 @@ spec:
   ipCidrRange: 10.0.0.0/20
   region: us-central1
   networkRef:
-    name: kuberay-kueue-vpc-kcc
+    name: gke-kuberay-kueue-multitenant-vpc-kcc
   privateIpGoogleAccess: true
   secondaryIpRange:
     - rangeName: pods

--- a/templates/gke-kuberay-kueue-multitenant/config-connector/nodepool.yaml
+++ b/templates/gke-kuberay-kueue-multitenant/config-connector/nodepool.yaml
@@ -15,7 +15,7 @@
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
 metadata:
-  name: kuberay-kueue-sys-kcc
+  name: gke-kuberay-kueue-multitenant-sys-kcc
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -24,7 +24,7 @@ metadata:
     cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
   clusterRef:
-    name: gke-kuberay-kueue-kcc
+    name: gke-kuberay-kueue-multitenant-cluster-kcc
   location: us-central1
   nodeLocations:
     - us-central1-a
@@ -37,6 +37,8 @@ spec:
     diskType: pd-standard
     oauthScopes:
       - https://www.googleapis.com/auth/cloud-platform
+    serviceAccountRef:
+      external: forge-builder@gca-gke-2025.iam.gserviceaccount.com
     workloadMetadataConfig:
       mode: GKE_METADATA
     labels:
@@ -46,7 +48,7 @@ spec:
 apiVersion: container.cnrm.cloud.google.com/v1beta1
 kind: ContainerNodePool
 metadata:
-  name: kuberay-kueue-gpu-kcc
+  name: gke-kuberay-kueue-multitenant-gpu-kcc
   namespace: forge-management
   labels:
     project: gcp-template-forge
@@ -55,7 +57,7 @@ metadata:
     cnrm.cloud.google.com/project-id: gca-gke-2025
 spec:
   clusterRef:
-    name: gke-kuberay-kueue-kcc
+    name: gke-kuberay-kueue-multitenant-cluster-kcc
   location: us-central1
   nodeLocations:
     - us-central1-a
@@ -74,6 +76,8 @@ spec:
           gpuDriverVersion: DEFAULT
     oauthScopes:
       - https://www.googleapis.com/auth/cloud-platform
+    serviceAccountRef:
+      external: forge-builder@gca-gke-2025.iam.gserviceaccount.com
     workloadMetadataConfig:
       mode: GKE_METADATA
     labels:


### PR DESCRIPTION
Closes #199

This PR implements the Config Connector path for the Multi-Tenant Ray on GKE template.

- Appends template name to KCC resources to ensure isolation during CI validation.
- Adds `serviceAccountRef` to GPU and System NodePools to match the TF equivalent.
- Updates documentation to reflect the resource naming change.