### PR TITLE
feat: OpenClaw foundations — SUCCESS.md, scaffolds, KCC registry, lint hardening

### DIFF
--- a/.gemini/SUCCESS.md
+++ b/.gemini/SUCCESS.md
@@ -1,0 +1,123 @@
+# Definition of Success for gcp-template-forge
+
+This file defines exactly what "done" means for every template implementation task.
+An agent completing a sub-issue MUST be able to check every item on this list before
+declaring success. Merging a PR that cannot pass this checklist is a failure.
+
+---
+
+## The Success Checklist
+
+A template implementation is **successful** when ALL of the following are true:
+
+### 1. Template Structure is Complete
+
+- [ ] `templates/<shortName>/template.yaml` exists with:
+  - `shortName` present, ≤ 20 characters, lowercase, hyphens only (no spaces, no underscores)
+  - `displayName`, `description`, `gcpServices`, `issueNumber` all populated
+- [ ] `templates/<shortName>/README.md` exists and documents BOTH deployment paths
+- [ ] `templates/<shortName>/validate.sh` exists and is executable
+
+### 2. Dual-Path Implementation is Present
+
+**Terraform + Helm path (`terraform-helm/`):**
+- [ ] `main.tf` provisions all required GCP infrastructure
+- [ ] `variables.tf` exposes `project_id`, `region`, `zone` (and any template-specific vars)
+- [ ] `outputs.tf` exports cluster name and relevant endpoints
+- [ ] `terraform fmt -check` passes with zero diff
+- [ ] `terraform validate` passes (after `terraform init`)
+- [ ] No `local-exec`, no `helm` provider, no hardcoded project IDs
+- [ ] Every `google_container_cluster` has `deletion_protection = false`
+- [ ] Every `google_container_node_pool` has `node_locations` explicitly set
+
+**Config Connector path (`config-connector/`):**
+- [ ] KCC manifests exist for all GCP resources — OR —
+- [ ] `.kcc-unsupported` file exists explaining which features are missing and why
+  (citing specific entries from `agent-infra/kcc-capabilities.yaml`)
+- [ ] No raw K8s workload manifests (Deployments, Services, etc.) in `config-connector/`
+
+**Workload manifests (`config-connector-workload/`):**
+- [ ] All raw K8s manifests (Deployments, Services, ConfigMaps, etc.) are here
+- [ ] Valid YAML: `python3 -c "import yaml; list(yaml.safe_load_all(open('file.yaml')))"` passes
+
+### 3. The Workload Actually Works (Most Important)
+
+This is the difference between "infrastructure provisioned" and "success."
+
+- [ ] **`validate.sh` passes all 5 tests**, including Test 5 (Functional Verification):
+  - The workload is **Running** (Deployment Available, pods in Running state)
+  - The workload is **serving or processing** — proven by ONE of:
+    - `curl http://<endpoint>` returns HTTP 2xx
+    - `kubectl exec` into pod + client command succeeds (psql, redis-cli PING, grpcurl, etc.)
+    - Custom resource reaches Ready/Active condition AND a test job/request completes
+  - **Reference:** `templates/basic-gke-hello-world/validate.sh` is the canonical example —
+    it curls the LoadBalancer IP and fails hard if the endpoint does not respond.
+    Every template must have an equivalent check for its own workload type.
+
+### 4. CI is Green
+
+- [ ] `TF PR Validation` check passes (lint + `terraform validate`)
+- [ ] `Sandbox Validation (TF)` check passes (deploy + validate.sh + destroy)
+- [ ] `Sandbox Validation (KCC)` check passes — OR — `.kcc-unsupported` is present
+- [ ] No stale TF state lock in `gs://gke-gca-2025-forge-tf-state/templates/<name>/`
+
+### 5. PR is Correct
+
+- [ ] PR title format: `feat: implement <shortName> template (closes #<issueNum>)`
+- [ ] PR body contains `Closes #<issueNum>` on its own line (required for circuit-breaker)
+- [ ] `gh pr merge --auto --merge <PR_NUM> --repo fkc1e100/gcp-template-forge` was run immediately after PR creation
+- [ ] Only files under `templates/<shortName>/` are changed — no workflow files, no other templates
+
+### 6. Published
+
+- [ ] PR is merged to `main` (auto-merge triggered and all checks passed)
+- [ ] `.validated` file committed by CI with `tf_helm: success` (and `kcc: success` or `kcc: skipped`)
+- [ ] Root `README.md` Published Templates table updated by `ci-post-merge.yml`
+
+### 7. Epic Closure (final step, after BOTH TF + KCC sub-issues succeed)
+
+- [ ] Both `[TF]` and `[KCC]` sub-issues are closed (or one is closed with `.kcc-unsupported`)
+- [ ] Parent EPIC issue is closed with a comment linking the merged PRs
+- [ ] `status:ai-agent-active` label removed from the EPIC
+
+---
+
+## What is NOT Success
+
+The following do NOT count as success even if CI appears green:
+
+- A `validate.sh` that only runs `kubectl wait --for=condition=available` without any
+  functional verification (Test 5 not implemented)
+- A PR where `terraform validate` was never run locally
+- A KCC path with broken manifests hidden behind `|| true`
+- A template that hardcodes `project_id = "gca-gke-2025"` instead of using `var.project_id`
+- A PR opened against a fork instead of `fkc1e100/gcp-template-forge` (WIF auth will fail)
+- Auto-merge NOT triggered (the PR will sit idle and never merge)
+
+---
+
+## Self-Assessment
+
+Before declaring your sub-issue complete, run this self-check:
+
+```bash
+# From the template directory:
+cd templates/<shortName>
+
+# 1. TF syntax
+terraform -chdir=terraform-helm fmt -check && echo "TF fmt: PASS"
+
+# 2. YAML validity
+for f in config-connector/*.yaml config-connector-workload/*.yaml; do
+  [ -f "$f" ] && python3 -c "import yaml; list(yaml.safe_load_all(open('$f')))" && echo "$f: PASS"
+done
+
+# 3. shortName length
+python3 -c "import yaml; d=yaml.safe_load(open('template.yaml')); n=d.get('shortName',''); assert len(n)<=20 and n==n.replace(' ','').replace('_',''), f'shortName FAIL: {n!r}'; print('shortName:', n, 'PASS')"
+
+# 4. validate.sh has Test 5 implemented (not the placeholder exit 1)
+grep -q "exit 1" validate.sh && echo "WARNING: validate.sh may still have placeholder exit 1" || echo "validate.sh Test 5: looks implemented"
+
+# 5. PR exists with auto-merge
+gh pr list --repo fkc1e100/gcp-template-forge --head "feature/issue-<NUM>" --json number,autoMergeRequest
+```

--- a/.gemini/user-instructions.json
+++ b/.gemini/user-instructions.json
@@ -3,9 +3,84 @@
   "guidelines": {
     "correctness": [
       {
-        "title": "GKE Dynamic Workload Scheduler (Queued Provisioning)",
-        "description": "Do NOT enable `queuedProvisioning` (or `queued_provisioning` in Terraform) on GKE node pools when deploying standard, long-running Kubernetes workloads like `Deployment`, `DaemonSet`, or `StatefulSet` via Helm. Queued Provisioning bypasses the standard cluster autoscaler and requires workloads to be submitted as batch `Job` resources (specifically Kueue workloads) to trigger node creation. If standard resources are used, the pods will remain stuck in a 'Pending' state indefinitely.",
-        "example": "If a template deploys a vLLM inference server using a standard Deployment Helm chart, ensure the GKE GPU node pool configuration uses standard autoscaling and does NOT include the `queued_provisioning { enabled = true }` block."
+        "title": "GKE Queued Provisioning — Standard Workloads",
+        "description": "Do NOT enable `queuedProvisioning` (or `queued_provisioning` in Terraform) on GKE node pools that serve standard long-running workloads like `Deployment`, `DaemonSet`, or `StatefulSet`. Queued Provisioning bypasses the standard cluster autoscaler and only triggers node creation for Kueue batch `Job` workloads. Standard pods will remain stuck `Pending` indefinitely.",
+        "example": "A vLLM inference server uses a standard Deployment — ensure the GPU node pool does NOT include `queued_provisioning { enabled = true }`."
+      },
+      {
+        "title": "Regional GKE Clusters — node_locations Required",
+        "description": "ALWAYS specify `node_locations` explicitly on `google_container_node_pool` when the cluster is regional (not zonal). Omitting `node_locations` causes a GKE API validation error. The list must contain zones within the cluster's region.",
+        "example": "node_locations = [\"us-central1-a\", \"us-central1-b\", \"us-central1-c\"]"
+      },
+      {
+        "title": "google_compute_subnetwork — No labels block",
+        "description": "The Terraform `google_compute_subnetwork` resource does NOT support a `labels` argument. Adding `labels = {}` causes `terraform apply` to fail immediately with an unsupported argument error. Never add labels to subnet resources.",
+        "example": "Remove any `labels` block from `google_compute_subnetwork` resources."
+      },
+      {
+        "title": "GPU Node Pools — No Zone Pinning",
+        "description": "Never hard-code a specific zone for GPU node pools (e.g., `node_locations = [\"us-central1-f\"]`). L4, A100, and H100 GPUs are frequently zone-exhausted. Templates MUST accept a `var.region` variable. The CI pipeline's three-region fallback (us-central1 → us-east1 → us-west1) handles zone selection. Add `variable \"region\" {}` to `variables.tf`.",
+        "example": "Use `var.region` throughout and let CI set `TF_VAR_region` per region attempt."
+      },
+      {
+        "title": "KubeRay + Kueue — CRD Install Order",
+        "description": "Kueue CRDs and the ClusterQueue/LocalQueue resources MUST be applied and Ready BEFORE any RayCluster or RayJob is created. Use `initContainers` in any workload that depends on Kueue CRDs to wait for their existence. Install Kueue via Helm (separate release) before the KubeRay operator release.",
+        "example": "Add `helm upgrade --install kueue kueue/kueue --wait` before `helm upgrade --install kuberay kuberay/kuberay-operator --wait`."
+      },
+      {
+        "title": "AI Model Staging — Large Weight Downloads",
+        "description": "For AI workloads (vLLM, Triton, etc.) that download model weights >1GB from Hugging Face or GCS: (1) deploy a Kubernetes `Job` FIRST to stage weights to a GCS bucket, (2) the serving `Deployment` MUST use an `initContainer` that waits for the Job to complete before starting the server, (3) set `progressDeadlineSeconds: 3600` on the Deployment. Helm's default --wait timeout will fail if the model download runs inside the Deployment readiness probe.",
+        "example": "Stage weights Job → initContainer waits → vLLM Deployment starts. Never download >1GB inside a Deployment's main container startup."
+      },
+      {
+        "title": "Cloud SQL — Private IP Requires Private Service Access",
+        "description": "When provisioning Cloud SQL with private IP, the VPC must have Private Service Access configured (`google_service_networking_connection` + `google_compute_global_address`). KCC `SQLInstance` takes 10-15 minutes to provision — set `kubectl wait --timeout=900s`. Always deploy Cloud SQL Auth Proxy as a sidecar for workload connectivity.",
+        "example": "Add `google_service_networking_connection` to main.tf before `google_sql_database_instance` with `ip_configuration { ipv4_enabled = false, private_network = ... }`."
+      },
+      {
+        "title": "GCS FUSE — Addon Required on Node Pool",
+        "description": "GKE node pools using GCS FUSE (CSI driver) must have the addon explicitly enabled on the cluster: `addons_config { gcs_fuse_csi_driver_config { enabled = true } }`. The CSI driver is not enabled by default on Standard clusters. Without this, PVCs using the `gcsfuse.csi.storage.gke.io` driver will remain `Pending`.",
+        "example": "Add to `google_container_cluster`: `addons_config { gcs_fuse_csi_driver_config { enabled = true } }`."
+      },
+      {
+        "title": "Gateway API — GKE Gateway Controller",
+        "description": "The GKE Gateway API controller (Envoy-based) must be enabled on the cluster: `gateway_api_config { channel = \"CHANNEL_STANDARD\" }` in the `google_container_cluster` resource. The `GatewayClass` name is `gke-l7-global-external-managed`. Gateway provisioning takes 3-5 minutes — validate.sh must poll for Gateway address, not assume immediate availability.",
+        "example": "Add `gateway_api_config { channel = \"CHANNEL_STANDARD\" }` to the cluster resource and poll with `kubectl get gateway -o jsonpath='{.status.addresses[0].value}'`."
+      },
+      {
+        "title": "Multi-Tenant Quota — Kueue ResourceFlavor Naming",
+        "description": "Kueue `ResourceFlavor` names must be unique cluster-wide and should include the template UID suffix to avoid collisions when multiple CI runs execute concurrently. Use `${BASE_NAME}-${UID_SUFFIX}` as the naming pattern, consistent with cluster and network naming.",
+        "example": "Name ResourceFlavor as `gpu-flavor-${UID_SUFFIX}` not just `gpu-flavor`."
+      },
+      {
+        "title": "KCC Feature Parity — Check Registry Before Generating",
+        "description": "Before generating any `config-connector/` manifests, read `agent-infra/kcc-capabilities.yaml` to check for unsupported features. If the template requires a feature listed as `action: kcc-unsupported-marker`, create a `.kcc-unsupported` file in the template root and document the limitation in README.md. Do NOT generate broken KCC manifests that will fail CI.",
+        "example": "If template needs `queuedProvisioning`, check kcc-capabilities.yaml → `action: kcc-unsupported-marker` → create `.kcc-unsupported`, skip KCC path."
+      },
+      {
+        "title": "Template Metadata — template.yaml Required",
+        "description": "Every template directory MUST contain a `template.yaml` file with at minimum: `shortName` (≤20 chars), `displayName`, `description`, `gcpServices` (list), and `issueNumber`. The `shortName` is used for GCP resource naming — CI will fail if it exceeds 20 characters or is missing.",
+        "example": "shortName: gke-ray-kueue\ndisplayName: Multi-Tenant Ray on GKE\ndescription: KubeRay + Kueue multi-tenant batch ML\ngcpServices: [GKE, GPU]\nissueNumber: 122"
+      },
+      {
+        "title": "Agent Plan Step — Post Before Coding",
+        "description": "Before creating any sub-issues or writing code for an EPIC, post a structured plan comment on the EPIC issue listing: (1) template directory name and shortName, (2) GCP resources TF path will create, (3) GCP resources KCC path will create, (4) known KCC limitations requiring .kcc-unsupported, (5) estimated validation time. Wait 30 minutes for a thumbs-down reaction before proceeding. Auto-proceed if no negative reaction.",
+        "example": "gh issue comment $EPIC_NUM --body '## Implementation Plan\\n**Template:** gke-ray-kueue\\n**TF path:** GKE cluster, GPU node pool, VPC\\n**KCC path:** ContainerCluster, ContainerNodePool (queuedProvisioning unsupported → .kcc-unsupported)\\n**Est. validation:** 25 min\\n\\nProceeding in 30 min unless thumbs-down reaction received.'"
+      },
+      {
+        "title": "Epic Sub-Issue Retry Limit",
+        "description": "Before creating a new sub-issue pair (TF + KCC) for a parent EPIC, count how many sub-issue pairs have already been created and closed without a successful merge. If 3 or more pairs have been attempted, do NOT create another. Post a comment on the EPIC with label `needs-human` explaining what was tried and what the specific blocker is. Stop work until a human responds.",
+        "example": "Search EPIC comments and linked issues. Count closed-without-merge sub-issue pairs. If >= 3: gh issue comment $EPIC --body 'needs-human: ...' && gh issue edit $EPIC --add-label needs-human && exit 0"
+      },
+      {
+        "title": "Carry Forward Failure Context into New Sub-Issues",
+        "description": "When creating a new sub-issue after a previous one failed, ALWAYS include the specific failure message from the previous PR's circuit-breaker comment in the new sub-issue body under a '## Previous Failure Context' section. Never start a new attempt without knowing what the last error was.",
+        "example": "gh pr view $PREV_PR --json comments -q '.comments[-1].body' → include in new issue body under '## Previous Failure Context'"
+      },
+      {
+        "title": "validate.sh MUST prove the workload works — not just that pods are Running",
+        "description": "A validate.sh that only checks 'kubectl wait --for=condition=available' is INCOMPLETE and will be treated as a CI failure. Every template's validate.sh MUST include at least one functional verification step that proves the workload is actually serving or processing: (A) curl/wget to an HTTP/HTTPS endpoint and verify a non-error HTTP response, OR (B) kubectl exec into a running pod and run a meaningful command (psql SELECT 1, redis-cli PING, grpcurl, etc.), OR (C) for batch/ML workloads: submit a test job or inference request and verify it completes successfully. Use the basic-gke-hello-world validate.sh as the reference — it curls the LoadBalancer IP and fails if the endpoint doesn't respond. The validate.sh scaffold's Test 5 section must be implemented; leaving it with 'exit 1' is not acceptable.",
+        "example": "Web service or API: curl http://${SERVICE_IP}/healthz or similar and assert HTTP 2xx. Database/cache: kubectl exec into app pod and run psql 'SELECT 1', redis-cli PING, or equivalent. Operator-managed CRD: kubectl wait <resource-kind> --for=condition=Ready. Batch/job workload: submit a minimal test job and wait for condition=Complete. Choose the pattern that fits the template's workload type — the basic-gke-hello-world curl pattern is the canonical reference."
       }
     ],
     "clarity": [],

--- a/.github/ISSUE_TEMPLATE/gke_architecture_request.yml
+++ b/.github/ISSUE_TEMPLATE/gke_architecture_request.yml
@@ -1,16 +1,123 @@
 name: New GKE Architecture Request
-description: Request a new GKE architecture template based on natural language intent.
-labels: [intent-capture]
+description: Request a new GKE architecture template. The AI agent will design, validate, and publish dual-path IaC (Terraform+Helm and Config Connector) from this issue.
+labels: [intent-capture, repo-agent]
 body:
   - type: markdown
     attributes:
       value: |
-        Please describe your desired GKE architecture in natural language.
+        ## Template Request
+        Fill in the fields below. The more specific you are, the fewer CI retries the agent will need.
+        The `Short Name` and `GCP Services` fields directly prevent the most common agent errors.
+
+  - type: input
+    id: display-name
+    attributes:
+      label: Template Display Name
+      description: Human-readable name shown in the template index.
+      placeholder: "Multi-Tenant Ray on GKE with Kueue"
+    validations:
+      required: true
+
+  - type: input
+    id: short-name
+    attributes:
+      label: Short Name (≤ 20 characters)
+      description: |
+        Used as the GKE cluster name prefix and in all GCP resource names. Must be ≤ 20 chars,
+        lowercase, hyphens only (no underscores). Example: gke-ray-kueue
+      placeholder: "gke-ray-kueue"
+    validations:
+      required: true
+
   - type: textarea
     id: intent
     attributes:
       label: Architecture Intent
-      description: "Example: I need a private GKE cluster that can run a high-traffic web app connecting to Cloud SQL."
-      placeholder: Describe your requirements here...
+      description: Describe what this template should demonstrate and why. Include workload type, scale, and any specific GKE features.
+      placeholder: |
+        Deploy a GKE cluster that supports multi-tenant batch ML workloads using KubeRay and
+        Kueue. Each tenant gets a Kueue ClusterQueue with resource quotas. A GPU node pool
+        serves Ray workers. An example RayJob should demonstrate end-to-end job submission.
     validations:
       required: true
+
+  - type: checkboxes
+    id: gcp-services
+    attributes:
+      label: GCP Services Required
+      description: Check all services this template will provision. This prevents the agent from guessing and hitting unsupported KCC features.
+      options:
+        - label: GKE Standard Cluster
+        - label: GKE Autopilot Cluster
+        - label: GPU Node Pool (L4 / A100 / H100)
+        - label: Spot / Preemptible Node Pool
+        - label: Cloud SQL (PostgreSQL / MySQL)
+        - label: Cloud Storage (GCS buckets)
+        - label: Pub/Sub (topics + subscriptions)
+        - label: Cloud Load Balancing (L4 / L7)
+        - label: Cloud NAT + Cloud Router
+        - label: VPC Network Peering / Private Service Access
+        - label: Workload Identity (IAM bindings)
+        - label: Artifact Registry
+        - label: GCS FUSE (CSI driver)
+        - label: Gateway API (Envoy Gateway)
+        - label: Topology-Aware Routing
+
+  - type: dropdown
+    id: kcc-path
+    attributes:
+      label: Config Connector (KCC) Path
+      description: |
+        KCC is 6-12 months behind Terraform in feature support. Choose "Best effort" if your
+        template uses cutting-edge GKE features (GPU DWS, queued provisioning, NAP, etc.).
+      options:
+        - "Required — full functional parity with Terraform path"
+        - "Best effort — skip KCC if features are unsupported (.kcc-unsupported marker)"
+        - "Not required — Terraform path only"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: cluster-mode
+    attributes:
+      label: GKE Cluster Mode
+      options:
+        - "Standard (node pool control required)"
+        - "Autopilot (managed nodes)"
+        - "Both (template should support either via variable)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: workload
+    attributes:
+      label: Workload / Application
+      description: Describe the workload the template should deploy to demonstrate the architecture works end-to-end.
+      placeholder: |
+        Deploy a sample RayJob (Python π estimation) that exercises the Kueue queue and
+        runs on the GPU node pool. The job should complete successfully and output a result.
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What must be true for this template to be considered complete and validated?
+      placeholder: |
+        - [ ] GKE cluster provisions with GPU node pool
+        - [ ] KubeRay operator and Kueue are installed and healthy
+        - [ ] ClusterQueue and LocalQueue created for each tenant namespace
+        - [ ] Sample RayJob submits, queues, runs on GPU node, and completes
+        - [ ] terraform destroy runs cleanly with no orphaned resources
+    validations:
+      required: true
+
+  - type: textarea
+    id: known-constraints
+    attributes:
+      label: Known Constraints or Limitations (optional)
+      description: |
+        Any known GKE API limitations, quota requirements, or KCC unsupported features.
+        The agent will use this to avoid wasting CI cycles.
+      placeholder: |
+        - queuedProvisioning on ContainerNodePool is NOT supported in KCC (use .kcc-unsupported)
+        - GPU quota required: at least 4x nvidia-l4 in us-central1 or us-east1

--- a/.github/workflows/sandbox-validation-kcc.yml
+++ b/.github/workflows/sandbox-validation-kcc.yml
@@ -14,8 +14,10 @@ on:
       - 'agent-infra/**'
 
 concurrency:
-  group: kcc-${{ github.ref }}
-  cancel-in-progress: true
+  # Share concurrency group with TF workflow to prevent concurrent .validated writes
+  # to the same branch. If both workflows fire on the same push, one will queue.
+  group: validation-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -83,9 +85,9 @@ jobs:
           echo "has_kcc_templates=$([ "$KCC_TEMPLATES" = "[]" ] && echo false || echo true)" >> "$GITHUB_OUTPUT"
           echo "KCC supported templates: $KCC_TEMPLATES"
 
-      - name: Remove status:ai-agent-active Label on Start
+      - name: Remove repo-agent Label on Start
         if: github.event_name == 'pull_request' && steps.find.outputs.has_kcc_templates == 'true'
-        run: gh pr edit ${{ github.event.number }} --remove-label "status:ai-agent-active" --repo ${{ github.repository }} || true
+        run: gh pr edit ${{ github.event.number }} --remove-label "repo-agent" --repo ${{ github.repository }} || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -518,7 +520,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add label
-        run: gh pr edit ${{ github.event.number }} --add-label "status:ai-agent-active" --repo ${{ github.repository }}
+        run: gh pr edit ${{ github.event.number }} --add-label "repo-agent" --repo ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -533,13 +535,16 @@ jobs:
           PR_NUM=${{ github.event.number }}
           # Wait for API to sync
           sleep 10
-          # Check if there are any non-completed or failed checks (excluding Auto-merge itself)
-          INCOMPLETE=$(gh pr checks $PR_NUM --json name,state,status | jq '[.[] | select(.name != "Auto-merge") | select(.status != "COMPLETED" or (.state != "SUCCESS" and .state != "SKIPPED" and .state != "NEUTRAL"))] | length')
+          # Check if there are any pending or failed checks (excluding Auto-merge itself).
+          # Valid --json fields for gh pr checks: name, state, startedAt, completedAt,
+          # bucket, description, event, link, workflow. There is no "status" field.
+          INCOMPLETE=$(gh pr checks $PR_NUM --repo ${{ github.repository }} --json name,state \
+            | jq '[.[] | select(.name != "Auto-merge") | select(.state != "SUCCESS" and .state != "SKIPPED" and .state != "NEUTRAL")] | length')
           if [ "$INCOMPLETE" -eq 0 ]; then
-             gh pr merge $PR_NUM --merge --delete-branch
+             gh pr merge $PR_NUM --repo ${{ github.repository }} --merge --delete-branch
           else
              echo "Still $INCOMPLETE checks pending or failed. Skipping auto-merge."
-             gh pr checks $PR_NUM
+             gh pr checks $PR_NUM --repo ${{ github.repository }}
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sandbox-validation-tf.yml
+++ b/.github/workflows/sandbox-validation-tf.yml
@@ -14,8 +14,10 @@ on:
       - 'agent-infra/**'
 
 concurrency:
-  group: tf-${{ github.ref }}
-  cancel-in-progress: true
+  # Share concurrency group with KCC workflow to prevent concurrent .validated writes
+  # to the same branch. If both workflows fire on the same push, one will queue.
+  group: validation-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -81,9 +83,9 @@ jobs:
           echo "has_tf_templates=$([ "$TF_TEMPLATES" = "[]" ] && echo false || echo true)" >> "$GITHUB_OUTPUT"
           echo "TF supported templates: $TF_TEMPLATES"
 
-      - name: Remove status:ai-agent-active Label on Start
+      - name: Remove repo-agent Label on Start
         if: github.event_name == 'pull_request' && steps.find.outputs.has_tf_templates == 'true'
-        run: gh pr edit ${{ github.event.number }} --remove-label "status:ai-agent-active" --repo ${{ github.repository }} || true
+        run: gh pr edit ${{ github.event.number }} --remove-label "repo-agent" --repo ${{ github.repository }} || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -680,7 +682,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add label
-        run: gh pr edit ${{ github.event.number }} --add-label "status:ai-agent-active" --repo ${{ github.repository }}
+        run: gh pr edit ${{ github.event.number }} --add-label "repo-agent" --repo ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -695,14 +697,16 @@ jobs:
           PR_NUM=${{ github.event.number }}
           # Wait for API to sync
           sleep 10
-          # Check if there are any non-completed or failed checks (excluding Auto-merge itself)
-          # We also exclude "Label Failure" and "Cleanup TF" as they might be skipped or irrelevant
-          INCOMPLETE=$(gh pr checks $PR_NUM --json name,state,status | jq '[.[] | select(.name != "Auto-merge") | select(.status != "COMPLETED" or (.state != "SUCCESS" and .state != "SKIPPED" and .state != "NEUTRAL"))] | length')
+          # Check if there are any pending or failed checks (excluding Auto-merge itself).
+          # Valid --json fields for gh pr checks: name, state, startedAt, completedAt,
+          # bucket, description, event, link, workflow. There is no "status" field.
+          INCOMPLETE=$(gh pr checks $PR_NUM --repo ${{ github.repository }} --json name,state \
+            | jq '[.[] | select(.name != "Auto-merge") | select(.state != "SUCCESS" and .state != "SKIPPED" and .state != "NEUTRAL")] | length')
           if [ "$INCOMPLETE" -eq 0 ]; then
-             gh pr merge $PR_NUM --merge --delete-branch
+             gh pr merge $PR_NUM --repo ${{ github.repository }} --merge --delete-branch
           else
              echo "Still $INCOMPLETE checks pending or failed. Skipping auto-merge."
-             gh pr checks $PR_NUM
+             gh pr checks $PR_NUM --repo ${{ github.repository }}
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,4 +1,51 @@
-# Project Infrastructure: gca-gke-2025 & Repo-Agent
+# Project Infrastructure: gca-gke-2025
+
+## Agent Quick-Start Reference
+
+Before working on any issue, read these files in order:
+
+| File | Purpose |
+|---|---|
+| **`.gemini/SUCCESS.md`** | **Read this first — defines exactly what "done" means for every template** |
+| `agent-infra/kcc-capabilities.yaml` | KCC unsupported features — check BEFORE generating config-connector/ manifests |
+| `.gemini/user-instructions.json` | Per-workload correctness rules (GPU, Ray, Cloud SQL, GCS FUSE, etc.) |
+| `agent-infra/scaffolds/README.template.md` | Starting point for every template README |
+| `agent-infra/scaffolds/validate.template.sh` | Starting point for every validate.sh |
+| `agent-infra/scaffolds/template.template.yaml` | Required metadata for every template |
+| `templates/basic-gke-hello-world/` | Complete working example — reference this |
+
+### OpenClaw Orchestration
+
+This project is driven by **OpenClaw** — a Gemini-powered autonomous agent running as a K8s
+Deployment in `openclaw-system` on the local K3s cluster. It is NOT the repowatch/repo-agent
+operator system.
+
+**How it works:**
+1. A GitHub Issue is labeled `repo-agent`
+2. `agent/watcher.sh` (running in `openclaw-watcher` pod) detects it and calls `bootstrap-epic.sh`
+3. `bootstrap-epic.sh` decomposes the EPIC into `[TF]` and `[KCC]` sub-issues, then runs
+   Tier-1 (local Gemma 4 via Ollama) and falls back to Tier-2 (Cloud Gemini `--yolo`)
+
+**To redeploy OpenClaw after script changes:**
+```bash
+# From forge-claw/ (the parent project directory):
+./k8s/deploy.sh --scripts   # fast: update ConfigMaps and restart pods
+./k8s/deploy.sh             # full: rebuild all K8s manifests
+```
+
+**To trigger processing of a stalled epic:**
+```bash
+# Re-add the trigger label — the watcher will pick it up within 60s
+gh issue edit <EPIC_NUM> --repo fkc1e100/gcp-template-forge --add-label repo-agent
+```
+
+**To watch agent logs:**
+```bash
+kubectl logs -n openclaw-system deploy/openclaw-watcher -f
+kubectl logs -n openclaw-system deploy/openclaw-agent -f
+```
+
+---
 
 ## Overview
 The project infrastructure is hosted on Google Cloud Platform (Project: `gca-gke-2025`) and consists of a management cluster and a workload cluster. The system uses Kubernetes-native patterns to manage both infrastructure (via Config Connector) and automated repository agents (via the Repo-Agent platform).
@@ -87,6 +134,11 @@ If the dashboard is inaccessible from specific devices or networks:
 *   **Workflow Fixes Separation:** The agent MUST NOT pile workflow fixes (e.g., `.github/workflows/` changes) in with template development issues. If the agent discovers a bug or improvement needed in the CI/CD workflows while working on a template, it MUST create a separate issue with the title/label prefix `[CI-BUG]` and address it in a separate PR.
 *   **Template Naming and Metadata:** When creating or updating a template, the agent MUST ensure it has a short, descriptive, and compliant name (at most 20 characters) to prevent violating GKE cluster and resource naming limits. This name MUST be stored in a standard `template.yaml` file at the root of the template directory with the key `shortName`. The agent should use Gemini to generate this short name if it is not provided.
 *   **Autonomous Auto-Merge:** When a sandbox agent successfully creates a Pull Request to fix an issue, it MUST immediately run `gh pr merge --auto --merge` on that PR. This ensures that once the CI checks turn green, the platform heals itself without waiting for human intervention.
+*   **Regional GKE Cluster `node_locations`:** ALWAYS specify `node_locations` explicitly on `google_container_node_pool` resources when deploying to a regional GKE cluster (e.g., `node_locations = ["us-central1-a", "us-central1-b", "us-central1-c"]`). Omitting `node_locations` causes Terraform to fail with a GKE API validation error on regional clusters.
+*   **`google_compute_subnetwork` has no `labels` block:** The Terraform `google_compute_subnetwork` resource does NOT support a `labels` argument. Never add a `labels = {}` block to subnet resources — it causes `terraform apply` to fail immediately with "unsupported argument".
+*   **GPU zone pinning is forbidden:** NEVER hard-code a specific zone for GPU node pools (e.g., `node_locations = ["us-central1-f"]`). L4 and A100 GPUs are frequently exhausted in specific zones. Always accept a `var.region` variable and let the CI pipeline's three-region fallback (us-central1 → us-east1 → us-west1) select an available zone. The template's `variables.tf` MUST declare `variable "region"`.
+*   **Epic Sub-Issue Retry Limit:** Before creating a new sub-issue pair (TF + KCC) for a parent EPIC, count how many sub-issue pairs have already been created and closed without a successful merge. To do this, search the EPIC's issue body and comments for linked closed issues/PRs. If **3 or more** sub-issue pairs have already been attempted, do NOT create another pair. Instead, post a comment on the EPIC issue with label `needs-human` that explains: (1) what was tried, (2) the specific error from the last failure, (3) what a human needs to decide. Stop work until a human responds.
+*   **Carry Forward Failure Context:** When creating a new sub-issue after a previous attempt failed, ALWAYS include the specific failure message from the previous PR's circuit-breaker comment in the new sub-issue body. Look at the closed PRs from the previous sub-issue and extract the last "Infrastructure failure detected" or circuit-breaker comment. Paste the failure excerpt into the new sub-issue's description under a `## Previous Failure Context` section. Never start a new attempt blind — the agent MUST know what the last error was.
 
 #### `fkc1e100/gcp-template-forge` (namespace for gcp-template-forge)
 ```yaml

--- a/README.md
+++ b/README.md
@@ -1,32 +1,36 @@
 # GCP Template Forge
 
-> An AI-driven pipeline that designs, deploys, and validates production-ready GKE reference architectures — dual-path (Terraform + Helm and Config Connector) — with every merge.
+> An autonomous, AI-driven Factory pipeline that designs, deploys, and validates production-ready GKE reference architectures — dual-path (Terraform + Helm and Config Connector) — triggered entirely by GitHub issues.
 
 ## Objectives
 
-1. **Design** — Use an AI agent (Gemini CLI + Claude) to author complete, enterprise-grade IaC templates from Google Cloud reference architectures, covering both Terraform/Helm and Config Connector deployment paths.
-2. **Deploy & Test** — Run every template through a full apply → verify → destroy cycle in a real GCP sandbox project before any PR is merged, and again after merge to confirm the published artifact works end-to-end.
-3. **Consolidate** — Act as a living, continuously-validated library of GKE patterns drawn from Google Cloud's public reference repositories, so teams can adopt them with confidence.
+1. **Autonomous Design** — Utilize a specialized AI Agent Factory (powered by Gemini models) to ingest GitHub Issues and autonomously author complete, enterprise-grade IaC templates from Google Cloud reference architectures, covering both Terraform/Helm and Config Connector deployment paths.
+2. **Deploy & Validate** — Ensure every generated template physically provisions in a real GCP sandbox (`gca-gke-2025`). The Agent actively monitors the deployment until all workloads reach a 'Running' state before opening a Pull Request. 
+3. **CI/CD Healing** — The Factory continuously monitors the repository's GitHub Actions pipeline. If CI validation fails, the Agent autonomously reads the logs, heals the codebase, and pushes fixes until the PR is green and mergeable.
+4. **Consolidate** — Act as a living, continuously-validated library of GKE patterns drawn from Google Cloud's public reference repositories, so platform teams can adopt them with confidence.
 
 ---
 
-## System Architecture
+## System Architecture: The Factory Approach
 
-The forge is powered by the operator stack from [`gke-labs/gemini-for-kubernetes-development`](https://github.com/gke-labs/gemini-for-kubernetes-development), running on a GKE Standard control-plane cluster.
+The Factory operates on an event-driven model where infrastructure requests are transformed into validated code through a closed-loop automated lifecycle, hosted on a dedicated GKE control-plane cluster.
 
 ```mermaid
 flowchart LR
-    DEV["👤 Developer\nopens issue"]
+    DEV["👤 Platform Architect\nopens GitHub Issue"]
 
-    subgraph OPS ["gke-labs Operator Stack"]
-        OV["🎯 Overseer + Repo-Agent\ncreates branch & PR"]
-        AG["🤖 Agent Sandbox\nauthors Terraform + KCC templates"]
-        OV --> AG
+    subgraph FACTORY ["Autonomous Factory Platform"]
+        WATCH["👁️ Watcher\ndetects Issue & creates branch"]
+        AG["🤖 AI Agent Sandbox\ndesigns TF/KCC & deploys locally"]
+        HEAL["🏥 CI Healer\nmonitors PR & fixes failures"]
+        WATCH --> AG
+        AG --> HEAL
     end
 
     subgraph GH ["GitHub — gcp-template-forge"]
-        PR["🔀 Pull Request\nlint · deploy-test-tf ∥ deploy-test-kcc"]
+        PR["🔀 Pull Request\nCI: lint · deploy-test"]
         MAIN["✅ main\nvalidated template library"]
+        HEAL -->|commits fixes| PR
         PR -->|approved + merged| MAIN
     end
 
@@ -35,151 +39,58 @@ flowchart LR
         KCC["☸️ Config Connector\ncluster"]
     end
 
-    DEV --> OV
-    AG -->|commits templates| PR
-    PR -->|deploy-test-tf| TF
-    PR -->|deploy-test-kcc| KCC
-    MAIN -->|validate-tf-helm ∥ validate-kcc\nthen publish-validated| TF
-    MAIN -->|validate-tf-helm ∥ validate-kcc\nthen publish-validated| KCC
+    DEV --> WATCH
+    AG -->|local pre-flight deployment| TF
+    AG -->|local pre-flight deployment| KCC
+    AG -->|opens PR| PR
+    PR -->|CI validation| TF
+    PR -->|CI validation| KCC
 ```
 
 ### Key Components
 
-| Component | Role | Repo |
-|---|---|---|
-| **Overseer** | Kubernetes operator that watches GitHub for new issues, coordinates the agent lifecycle, and manages PR state | [`gke-labs/gemini-for-kubernetes-development`](https://github.com/gke-labs/gemini-for-kubernetes-development) |
-| **Repo-Agent** | Creates GitHub issues, branches, and PRs; posts status comments; triggers the agent sandbox | same |
-| **AgentSandboxes** | Kubernetes Jobs that spin up an isolated Gemini CLI session per template; the agent authors all IaC files and commits them | same |
-| **CI Service Account** | GCP service account used by GitHub Actions CI to authenticate and run Terraform/Helm/KCC against the sandbox project | `agent-infra/` |
+| Component | Role |
+|---|---|
+| **The Watcher** | A continuous polling service that monitors the repository for issues tagged with `status:ai-agent-active`. It provisions the workspace, creates a git branch, and delegates the task to the Agent Factory. |
+| **Agent Factory** | An isolated environment that executes the LLM reasoning loop. The Factory reads repository standards, authors dual-path IaC files, and executes physical deployments against the sandbox project to ensure the architecture is functional. |
+| **CI Healer** | An active polling loop that monitors the GitHub Actions CI pipeline for a given PR. If checks fail (e.g. linting or validation), the Healer automatically fetches logs, applies fixes to the code, and pushes a new commit to restore pipeline health. |
+| **The Housekeeper** | A cron job that purges orphaned GCP infrastructure, breaks stale Terraform state locks, and cleans up the sandbox to maintain budget and quota efficiency. |
 
 ### Repository Layout
 
 ```
 .github/
   workflows/
-    sandbox-validation-*.yml  ← lint · deploy-test-tf ∥ deploy-test-kcc (PR) · validate-tf-helm ∥ validate-kcc · publish-validated (push)
-  ISSUE_TEMPLATE/           ← template request form
+    sandbox-validation-*.yml  ← Parallel CI gates (Lint, TF Deploy, KCC Deploy)
+    cleanup-orphans.yml       ← Automated quota management
 agent-infra/
-  terraform/                ← control-plane GKE cluster + CI service account
-  manifests/                ← Overseer + Repo-Agent + AgentSandboxes deployments
-templates/                  ← validated template library (see Templates section below)
-GEMINI.md                   ← guardrails and instructions for the Gemini CLI agent
-GUIDANCE.md                 ← manual setup steps (identity, Secret Manager)
+  manifests/                ← Deployment manifests for the Factory infrastructure
+templates/                  ← Validated template library
+README.md                   ← This document
 ```
 
 ---
 
-## CI Pipeline
+## The Deployment Lifecycle
 
-### Job dependency graph
+### 1. Issue Ingestion
+A user opens an Epic detailing architectural requirements. The Watcher detects the issue and triggers the Agent Factory.
 
-```mermaid
-flowchart LR
-    DC(["🔍 detect-changes\nDiff PR head SHA or push\nagainst base — outputs\nchanged template list"])
+### 2. Research & Strategy
+The Factory clones the repository and reads local architectural standards (like this `README.md`) to apply strict formatting, unique resource naming conventions, and constraints.
 
-    subgraph pr ["━━━  Pull Request  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"]
-        direction LR
-        L(["🔎 lint\nper template\ntf fmt · tf validate\nhelm lint · KCC YAML\nboth-paths check"])
-        DTTF(["🏗️ deploy-test-tf\nper template\nTF apply → verify → Helm deploy\n→ security scan → TF destroy\nPost PR summary comment"])
-        DTKCC(["☸️ deploy-test-kcc\nper template\nKCC apply → wait Ready\n→ delete\nPost PR summary comment"])
-    end
+### 3. Dual-Path Execution & Pre-flight
+The Factory authors the code for both paths:
+*   **Terraform/Helm (`terraform-helm/`)**: Provisions infrastructure via Terraform and deploys operator workloads (e.g., KubeRay, Kueue) via Helm.
+*   **Config Connector (`config-connector/`)**: Provisions infra via raw KRM YAML and independently deploys the necessary operators and CRDs to prove the architecture's intent.
 
-    subgraph push ["━━━  Push to main  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"]
-        direction LR
-        VTH(["🏗️ validate-tf-helm\nper template · 120 min timeout\nTF apply → verify cluster\nRUNNING → TF destroy\nSaves results artifact"])
-        VKCC(["☸️ validate-kcc\nper template · 120 min timeout\nFresh runner — KCC cluster\ncreds from the start\nKCC apply → wait Ready\n→ delete\nSaves results artifact"])
-        PUB(["📋 publish-validated\nper template\nAccumulate agent metrics\nUpdate README + .validated\n.agent-metrics-cumulative\ngit push [skip ci]"])
-    end
+The Factory executes these files natively against GCP, running an active polling loop to verify the resources reach a `RUNNING` status.
 
-    DC --> L
-    L --> DTTF
-    L --> DTKCC
-    DC --> VTH
-    DC --> VKCC
-    VTH --> PUB
-    VKCC --> PUB
-```
-
-> `deploy-test-tf` and `deploy-test-kcc` run **in parallel** on separate runners after lint passes. Likewise, `validate-tf-helm` and `validate-kcc` both run in parallel on push to main — GCP resource name collisions are avoided by the `-tf` / `-kcc` suffix convention on all resource names. `publish-validated` waits for both validate jobs to complete before updating the README and `.validated` marker.
-
-### End-to-end sequence
-
-```mermaid
-sequenceDiagram
-    actor Dev as Developer / Overseer
-    participant GH as GitHub
-    participant CI as GitHub Actions
-    participant GCP as GCP Sandbox
-
-    Dev->>GH: Open issue (template request)
-    GH->>CI: Overseer creates branch + triggers AgentSandbox
-    CI->>GH: Agent commits terraform-helm/ + config-connector/
-
-    Note over GH,CI: ── Pull Request CI Gate ──────────────────────────────
-    GH->>CI: PR opened → detect-changes (PR head SHA diff)
-    CI->>CI: lint: tf fmt/validate · helm lint · KCC YAML · both-paths check
-    par deploy-test-tf (parallel)
-        CI->>GCP: TF apply (VPC · cluster · node pool)
-        GCP-->>CI: cluster RUNNING ✓
-        CI->>GCP: helm upgrade --install
-        GCP-->>CI: workload ready ✓
-        CI->>GCP: TF destroy
-    and deploy-test-kcc (parallel)
-        CI->>GCP: KCC apply (Config Connector manifests)
-        GCP-->>CI: ContainerCluster Ready ✓
-        CI->>GCP: kubectl delete (KCC teardown)
-    end
-    CI->>GH: Post deploy summary comment to PR (both paths)
-    Dev->>GH: Review + merge PR
-
-    Note over GH,CI: ── Post-Merge CI Gate (4 independent jobs) ──────────
-    GH->>CI: push to main → detect-changes
-    par validate-tf-helm (parallel)
-        CI->>CI: skip-check (changed since last .validated?)
-        CI->>GCP: TF apply (VPC · cluster · node pool · Helm workload)
-        GCP-->>CI: cluster RUNNING ✓  nodes ready ✓
-        CI->>GCP: TF destroy (full teardown)
-    and validate-kcc (parallel)
-        CI->>CI: skip-check (changed since last .validated?)
-        CI->>GCP: kubectl apply (KCC manifests)
-        GCP-->>CI: ContainerCluster Ready ✓
-        CI->>GCP: kubectl delete (KCC teardown)
-    end
-    CI->>CI: publish-validated starts (waits for both above)
-    CI->>CI: accumulate .agent-metrics across all sandbox sessions
-    CI->>GH: Commit README.md + .validated + .agent-metrics-cumulative
-```
-
-### Template structure
-
-```
-templates/<name>/
-├── terraform-helm/              ← Terraform + Helm deployment path
-│   ├── main.tf                  ← VPC · cluster · workload resources
-│   ├── variables.tf
-│   ├── versions.tf              ← pinned provider versions + GCS backend
-│   ├── outputs.tf               ← cluster_name + cluster_location (required by CI)
-│   └── workload/                ← Helm chart for the workload
-│       ├── Chart.yaml
-│       ├── values.yaml
-│       └── templates/
-├── config-connector/            ← Config Connector (KCC) deployment path
-│   ├── network.yaml             ← ComputeNetwork + ComputeSubnetwork
-│   ├── cluster.yaml             ← ContainerCluster (+ NodePool if standard)
-│   └── workload/                ← Kubernetes manifests for the workload (required)
-│       └── *.yaml               ← Deployment · Service · HPA · NetworkPolicy etc.
-├── README.md                    ← auto-updated by CI with validation record
-├── .validated                   ← CI marker: commit + status after successful deploy
-├── .agent-metrics               ← written by agent sandbox (latest session)
-└── .agent-metrics-cumulative    ← CI-maintained running total across all sessions
-```
-
-**CI enforcement rules:**
-- Both `terraform-helm/` and `config-connector/` must exist (lint fails otherwise)
-- `google_container_cluster` must have `deletion_protection = false`
-- KCC manifests must not use `cnrm.cloud.google.com/deletion-policy: abandon`
-- Resources must use template-based names (e.g., `enterprise-gke-vpc`) not issue numbers
-- `validate-tf-helm` / `validate-kcc` re-run whenever the template changes since last `.validated` commit
+### 4. Continuous CI Validation
+Once the PR is opened, the native GitHub Actions pipeline acts as the independent gatekeeper:
+1. **Linting:** Validates formatting (`terraform fmt`) and YAML syntax.
+2. **Parallel Deployments:** Distinct jobs spin up the TF path and the KCC path simultaneously to prevent naming collisions.
+3. **Healing:** If the CI pipeline fails, the Factory's Healer intervenes, reads the log, pushes a fix, and waits for a green build.
 
 ---
 
@@ -195,20 +106,15 @@ templates/<name>/
 
 ---
 
-## Public Reference Sources
+## Handling GCP Quota Errors
+If your CI run or local Factory deployment fails with a quota limit error (e.g., `Quota 'NETWORKS' exceeded. Limit: 30.0 globally`), it means previous runs have left orphaned resources clogging up the project. You must not attempt to modify your template code if the only failure is a quota limit. 
 
-The forge validates patterns drawn from:
-
-| Source | Focus |
-|---|---|
-| [Cloud Foundation Toolkit](https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit) | GCP security baselines |
-| [Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit) | HPC + AI/ML clusters |
-| [Kubernetes Engine Samples](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples) | GKE workload patterns |
-| [Terraform GKE Modules](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine) | Reusable TF modules |
-| [GKE AI Labs](https://gke-ai-labs.dev/) | AI/ML on GKE |
-| [Gemini for Kubernetes Development](https://github.com/gke-labs/gemini-for-kubernetes-development) | Operator stack powering this forge |
-| [Accelerated Platforms](https://github.com/GoogleCloudPlatform/accelerated-platforms) | GPU/TPU workloads |
-| [GKE Policy Automation](https://github.com/google/gke-policy-automation) | Policy as code |
-| [LLM-D](https://github.com/llm-d/llm-d) | LLM inference on GKE |
-# Test Janitor
-This was tested by closing issue #137.
+Instead, execute the following command in your terminal to manually trigger the Housekeeper workflow:
+```bash
+gh workflow run cleanup-orphans.yml --repo fkc1e100/gcp-template-forge
+```
+After the cleanup finishes, push an empty commit to your branch to re-trigger the pipeline:
+```bash
+git commit --allow-empty -m "ci: retry after quota cleanup"
+git push origin HEAD
+```

--- a/agent-infra/kcc-capabilities.yaml
+++ b/agent-infra/kcc-capabilities.yaml
@@ -21,6 +21,7 @@ unsupported:
     tf_resource: google_container_node_pool
     tf_field: node_pool.queued_provisioning.enabled
     kcc_resource: ContainerNodePool
+    kcc_search_key: "queuedProvisioning"
     action: kcc-unsupported-marker
     reason: >
       KCC v1beta1 ContainerNodePool lacks the queuedProvisioning field.
@@ -76,6 +77,7 @@ unsupported:
     tf_resource: google_container_node_pool
     tf_field: node_pool.node_config.confidential_nodes
     kcc_resource: ContainerNodePool
+    kcc_search_key: "confidentialNodes"
     action: kcc-unsupported-marker
     reason: >
       Confidential node configuration is not available in KCC ContainerNodePool.

--- a/agent-infra/kcc-capabilities.yaml
+++ b/agent-infra/kcc-capabilities.yaml
@@ -1,0 +1,150 @@
+# KCC Capability Registry
+#
+# Lists known unsupported Config Connector features as of 2026-Q2.
+# KCC is typically 6-12 months behind the Terraform provider in feature parity.
+#
+# AGENT USAGE: Read this file BEFORE generating any config-connector/ manifests.
+# - If a feature your template requires is listed under `unsupported`, follow
+#   the `action` field: either create a .kcc-unsupported marker file or use
+#   the listed workaround.
+# - If a feature is listed under `workarounds`, use the kcc_equivalent pattern
+#   instead of the terraform field.
+# - If you discover a new unsupported feature during CI, add it here and
+#   create a separate [CI-BUG] issue documenting the gap.
+#
+# LINT: local-lint.sh checks that any template using a field listed here
+# under action: kcc-unsupported-marker has a .kcc-unsupported file present.
+
+unsupported:
+  - feature: queuedProvisioning
+    resource: ContainerNodePool
+    tf_resource: google_container_node_pool
+    tf_field: node_pool.queued_provisioning.enabled
+    kcc_resource: ContainerNodePool
+    action: kcc-unsupported-marker
+    reason: >
+      KCC v1beta1 ContainerNodePool lacks the queuedProvisioning field.
+      KCC generates resources from the Terraform provider proto but this
+      field has not yet been mapped.
+    upstream_issue: https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/TBD
+    workaround: >
+      Use standard autoscaling in the KCC path. Document the limitation in
+      README.md under a "KCC Limitations" section.
+
+  - feature: subnetwork_labels
+    resource: ComputeSubnetwork
+    tf_resource: google_compute_subnetwork
+    tf_field: labels
+    kcc_resource: ComputeSubnetwork
+    action: omit
+    reason: >
+      KCC ComputeSubnetwork does not support resource labels. The field is
+      silently ignored in some versions and causes failures in others.
+      Labels on subnets provide no functional value for these templates.
+    workaround: >
+      Simply omit the labels block from ComputeSubnetwork KCC manifests.
+      Labels can be applied to ContainerCluster and ContainerNodePool instead.
+
+  - feature: network_policy_config_provider_calico
+    resource: ContainerCluster
+    tf_resource: google_container_cluster
+    tf_field: network_policy.provider = "CALICO"
+    kcc_resource: ContainerCluster
+    action: omit
+    reason: >
+      KCC ContainerCluster does not support the network_policy.provider field.
+      DataplaneV2 (the modern equivalent) is configured via datapathProvider instead.
+    workaround: >
+      Use `spec.datapathProvider: ADVANCED_DATAPATH` in KCC to enable network
+      policy enforcement without specifying Calico explicitly.
+
+  - feature: node_pool_placement_policy
+    resource: ContainerNodePool
+    tf_resource: google_container_node_pool
+    tf_field: node_pool.placement_policy
+    kcc_resource: ContainerNodePool
+    action: omit
+    reason: >
+      Node pool placement policies (COMPACT for GPU colocation) are not
+      supported in KCC ContainerNodePool v1beta1.
+    workaround: >
+      Omit placement_policy from the KCC path. Document in README.md that
+      compact placement is only available via the Terraform path.
+
+  - feature: confidential_nodes
+    resource: ContainerNodePool
+    tf_resource: google_container_node_pool
+    tf_field: node_pool.node_config.confidential_nodes
+    kcc_resource: ContainerNodePool
+    action: kcc-unsupported-marker
+    reason: >
+      Confidential node configuration is not available in KCC ContainerNodePool.
+    workaround: >
+      Create a .kcc-unsupported marker. The Terraform path fully supports
+      confidential nodes. Document the limitation in README.md.
+
+workarounds:
+  - feature: regional_cluster_node_locations
+    tf_resource: google_container_node_pool
+    tf_field: node_locations
+    kcc_resource: ContainerNodePool
+    kcc_field: spec.locations
+    note: >
+      KCC uses spec.locations (array of zone strings) on ContainerNodePool,
+      equivalent to Terraform's node_locations. Always specify this explicitly
+      for regional clusters to avoid API validation errors.
+    example: |
+      spec:
+        locations:
+          - us-central1-a
+          - us-central1-b
+          - us-central1-c
+
+  - feature: workload_identity_config
+    tf_resource: google_container_cluster
+    tf_field: workload_identity_config.workload_pool
+    kcc_resource: ContainerCluster
+    kcc_field: spec.workloadIdentityConfig.workloadPool
+    note: >
+      KCC uses spec.workloadIdentityConfig.workloadPool. Set to
+      "${PROJECT_ID}.svc.id.goog" to enable Workload Identity.
+    example: |
+      spec:
+        workloadIdentityConfig:
+          workloadPool: PROJECT_ID.svc.id.goog
+
+  - feature: dataplane_v2
+    tf_resource: google_container_cluster
+    tf_field: datapath_provider = "ADVANCED_DATAPATH"
+    kcc_resource: ContainerCluster
+    kcc_field: spec.datapathProvider
+    note: >
+      KCC uses spec.datapathProvider: ADVANCED_DATAPATH to enable GKE
+      Dataplane V2 (eBPF-based network policy enforcement).
+    example: |
+      spec:
+        datapathProvider: ADVANCED_DATAPATH
+
+  - feature: release_channel
+    tf_resource: google_container_cluster
+    tf_field: release_channel.channel
+    kcc_resource: ContainerCluster
+    kcc_field: spec.releaseChannel.channel
+    note: >
+      KCC uses spec.releaseChannel.channel. Valid values: RAPID, REGULAR, STABLE.
+    example: |
+      spec:
+        releaseChannel:
+          channel: REGULAR
+
+  - feature: gateway_api_config
+    tf_resource: google_container_cluster
+    tf_field: gateway_api_config.channel
+    kcc_resource: ContainerCluster
+    kcc_field: spec.gatewayApiConfig.channel
+    note: >
+      KCC ContainerCluster supports Gateway API config via spec.gatewayApiConfig.
+    example: |
+      spec:
+        gatewayApiConfig:
+          channel: CHANNEL_STANDARD

--- a/agent-infra/local-lint.sh
+++ b/agent-infra/local-lint.sh
@@ -35,13 +35,13 @@ echo "$TEMPLATES" | while read -r template; do
   [ -z "$template" ] && continue
   template_name=$(basename "$template")
   [ "$template_name" == "README.md" ] && continue
-  
+
   echo "--- Checking structure of $template_name ---"
   MISSING=""
-  if [ "$LINT_MODE" == "TF" ]; then
+  if [ "$LINT_MODE" == "TF" ] || [ -z "$LINT_MODE" ]; then
     [ ! -d "${template}/terraform-helm" ] && MISSING="${MISSING} terraform-helm/"
   fi
-  if [ "$LINT_MODE" == "KCC" ]; then
+  if [ "$LINT_MODE" == "KCC" ] || [ -z "$LINT_MODE" ]; then
     if [ ! -f "${template}/.kcc-unsupported" ]; then
       [ ! -d "${template}/config-connector" ] && MISSING="${MISSING} config-connector/"
     fi
@@ -49,6 +49,63 @@ echo "$TEMPLATES" | while read -r template; do
   if [ -n "$MISSING" ]; then
     echo "ERROR: Template '${template_name}' is missing required directories:${MISSING}"
     exit 1
+  fi
+
+  # Mandate: template.yaml must exist with a valid shortName
+  if [ ! -f "${template}/template.yaml" ]; then
+    echo "ERROR: Template '${template_name}' is missing template.yaml (required for resource naming and index)"
+    exit 1
+  fi
+  SHORT_NAME=$(python3 -c "
+import yaml, sys
+try:
+    d = yaml.safe_load(open('${template}/template.yaml'))
+    print(d.get('shortName',''))
+except Exception as e:
+    print('', file=sys.stderr)
+    sys.exit(1)
+" 2>/dev/null || true)
+  if [ -z "$SHORT_NAME" ]; then
+    echo "ERROR: ${template}/template.yaml is missing or has empty 'shortName' field"
+    exit 1
+  fi
+  if [ ${#SHORT_NAME} -gt 20 ]; then
+    echo "ERROR: ${template}/template.yaml shortName '${SHORT_NAME}' exceeds 20 characters (${#SHORT_NAME} chars)"
+    exit 1
+  fi
+
+  # KCC capability check: warn if KCC manifests use known-unsupported fields without .kcc-unsupported
+  if [ -d "${template}/config-connector" ] && [ ! -f "${template}/.kcc-unsupported" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    KCC_CAP="${SCRIPT_DIR}/kcc-capabilities.yaml"
+    if [ -f "$KCC_CAP" ]; then
+      python3 - "${template}/config-connector" "$KCC_CAP" "${template}" << 'KCCPY'
+import yaml, sys, pathlib
+cc_dir, cap_file, template_dir = sys.argv[1], sys.argv[2], sys.argv[3]
+caps = yaml.safe_load(open(cap_file))
+unsupported = {u['tf_field'].split('.')[-1]: u for u in caps.get('unsupported', [])
+               if u.get('action') == 'kcc-unsupported-marker'}
+errors = []
+for p in pathlib.Path(cc_dir).rglob('*.yaml'):
+    try:
+        for doc in yaml.safe_load_all(p.read_text()):
+            if not doc: continue
+            content = p.read_text()
+            for field, info in unsupported.items():
+                # Check for the KCC field name (last segment) in manifest content
+                kcc_field = info.get('kcc_field', field)
+                search_key = kcc_field.split('.')[-1] if '.' in kcc_field else field
+                if search_key in content:
+                    errors.append(f"  {p}: uses '{search_key}' which maps to unsupported TF field '{info['tf_field']}'")
+    except Exception:
+        pass
+if errors:
+    print(f"ERROR: {template_dir}/config-connector/ references known-unsupported KCC fields without a .kcc-unsupported marker:")
+    for e in errors: print(e)
+    print(f"  Fix: create '{template_dir}/.kcc-unsupported' or remove the unsupported field.")
+    sys.exit(1)
+KCCPY
+    fi
   fi
 
   # Check for non-standard directories

--- a/agent-infra/local-lint.sh
+++ b/agent-infra/local-lint.sh
@@ -83,20 +83,22 @@ except Exception as e:
 import yaml, sys, pathlib
 cc_dir, cap_file, template_dir = sys.argv[1], sys.argv[2], sys.argv[3]
 caps = yaml.safe_load(open(cap_file))
-unsupported = {u['tf_field'].split('.')[-1]: u for u in caps.get('unsupported', [])
-               if u.get('action') == 'kcc-unsupported-marker'}
+# Build search entries: use kcc_search_key when present (explicit), else feature name.
+# Never use the last segment of tf_field — it's often too generic (e.g. 'enabled').
+unsupported = []
+for u in caps.get('unsupported', []):
+    if u.get('action') != 'kcc-unsupported-marker':
+        continue
+    search_key = u.get('kcc_search_key') or u.get('feature', '')
+    if search_key:
+        unsupported.append((search_key, u))
 errors = []
 for p in pathlib.Path(cc_dir).rglob('*.yaml'):
     try:
-        for doc in yaml.safe_load_all(p.read_text()):
-            if not doc: continue
-            content = p.read_text()
-            for field, info in unsupported.items():
-                # Check for the KCC field name (last segment) in manifest content
-                kcc_field = info.get('kcc_field', field)
-                search_key = kcc_field.split('.')[-1] if '.' in kcc_field else field
-                if search_key in content:
-                    errors.append(f"  {p}: uses '{search_key}' which maps to unsupported TF field '{info['tf_field']}'")
+        content = p.read_text()
+        for search_key, info in unsupported:
+            if search_key in content:
+                errors.append(f"  {p}: uses '{search_key}' which maps to unsupported TF field '{info['tf_field']}'")
     except Exception:
         pass
 if errors:

--- a/agent-infra/scaffolds/README.template.md
+++ b/agent-infra/scaffolds/README.template.md
@@ -1,0 +1,167 @@
+# {{DISPLAY_NAME}}
+
+> {{ONE_LINE_DESCRIPTION}}
+
+<!-- CI: validation record appended here by ci-post-merge.yml — do not edit below this line manually -->
+
+## Architecture
+
+{{DESCRIBE_THE_ARCHITECTURE_HERE}}
+
+This template provisions:
+
+- **VPC Network** — Dedicated VPC with a primary subnet in `{{REGION}}`
+- **GKE Cluster** — {{CLUSTER_TYPE}} cluster (`{{SHORT_NAME}}`) with {{NODE_POOL_DESCRIPTION}}
+- **Workload** — {{WORKLOAD_DESCRIPTION}}
+
+### Resource Naming
+
+| Resource | Terraform + Helm | Config Connector |
+|---|---|---|
+| GKE Cluster | `{{SHORT_NAME}}-<uid>-tf` | `{{SHORT_NAME}}-<uid>-kcc` |
+| VPC Network | `{{SHORT_NAME}}-<uid>-tf-vpc` | `{{SHORT_NAME}}-<uid>-kcc-vpc` |
+| Subnet | `{{SHORT_NAME}}-<uid>-tf-subnet` | `{{SHORT_NAME}}-<uid>-kcc-subnet` |
+
+### Estimated Cost
+
+| Resource | Monthly Estimate |
+|---|---|
+| GKE Cluster (control plane) | ~$75 |
+| {{NODE_POOL_TYPE}} Node Pool ({{NODE_COUNT}}x {{MACHINE_TYPE}}) | ~${{NODE_COST}} |
+| **Total** | **~${{TOTAL_COST}}** |
+
+*Estimates based on sustained use in us-central1. GPU templates incur additional on-demand charges.*
+
+---
+
+## Deployment Paths
+
+This template supports two deployment paths that provision equivalent infrastructure.
+
+### Path 1: Terraform + Helm
+
+**Prerequisites:** `terraform` ≥ 1.5, `helm` ≥ 3.10, `kubectl`, `gcloud` with ADC configured.
+
+```bash
+cd templates/{{TEMPLATE_DIR}}/terraform-helm
+
+# Initialize with GCS backend (or use local state for testing)
+terraform init \
+  -backend-config="bucket=YOUR_TF_STATE_BUCKET" \
+  -backend-config="prefix={{TEMPLATE_DIR}}/terraform-helm"
+
+# Review the plan
+terraform plan \
+  -var="project_id=YOUR_PROJECT_ID" \
+  -var="region=us-central1"
+
+# Apply (provisions GKE cluster and supporting infrastructure)
+terraform apply \
+  -var="project_id=YOUR_PROJECT_ID" \
+  -var="region=us-central1"
+
+# Get cluster credentials
+CLUSTER_NAME=$(terraform output -raw cluster_name)
+REGION=$(terraform output -raw cluster_location)
+gcloud container clusters get-credentials "${CLUSTER_NAME}" --region "${REGION}"
+
+# Deploy the workload via Helm
+helm upgrade --install release ./helm --wait --timeout=30m
+
+# Verify
+kubectl get nodes
+kubectl get pods -A
+```
+
+**Cleanup:**
+```bash
+helm uninstall release
+terraform destroy -var="project_id=YOUR_PROJECT_ID" -var="region=us-central1"
+```
+
+---
+
+### Path 2: Config Connector (KCC)
+
+**Prerequisites:** A running GKE cluster with Config Connector installed. See the
+[KCC installation guide](https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall).
+The `forge-management` namespace must have a `ConfigConnectorContext` pointing to a
+service account with `roles/container.admin` and `roles/compute.networkAdmin`.
+
+```bash
+cd templates/{{TEMPLATE_DIR}}/config-connector
+
+# Apply the GCP infrastructure manifests
+kubectl apply -n forge-management -f .
+
+# Wait for all resources to be Ready (GKE cluster takes ~10 minutes)
+kubectl wait -n forge-management --for=condition=Ready --all \
+  --timeout=3600s -f .
+
+# Get cluster credentials (once ContainerCluster is Ready)
+CLUSTER_NAME=$(kubectl get containerclusters.container.cnrm.cloud.google.com \
+  -n forge-management -l "template={{SHORT_NAME}}" \
+  -o jsonpath='{.items[0].metadata.name}')
+LOCATION=$(kubectl get containerclusters.container.cnrm.cloud.google.com \
+  -n forge-management -l "template={{SHORT_NAME}}" \
+  -o jsonpath='{.items[0].spec.location}')
+gcloud container clusters get-credentials "${CLUSTER_NAME}" --region "${LOCATION}"
+
+# Deploy the workload
+kubectl apply -n default -f ../config-connector-workload/
+
+# Verify
+kubectl get nodes
+kubectl get pods -A
+```
+
+**Cleanup:**
+```bash
+kubectl delete -n default -f ../config-connector-workload/
+kubectl delete -n forge-management -f . --wait=true --timeout=900s
+```
+
+{{KCC_LIMITATIONS_SECTION}}
+<!--
+If any KCC limitations apply, replace the line above with:
+
+### KCC Limitations
+
+- **{{FEATURE_NAME}}**: Not supported in KCC v1beta1 ContainerNodePool. The Terraform path
+  uses `{{TF_FIELD}}` for this capability. Tracked upstream:
+  https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/TBD
+-->
+
+---
+
+## Verification
+
+After deploying with either path, run the validation script to confirm end-to-end functionality:
+
+```bash
+export PROJECT_ID="YOUR_PROJECT_ID"
+export CLUSTER_NAME="<cluster-name-from-outputs>"
+export REGION="us-central1"
+chmod +x templates/{{TEMPLATE_DIR}}/validate.sh
+./templates/{{TEMPLATE_DIR}}/validate.sh
+```
+
+Expected output:
+```
+Test 1: Cluster Connectivity... Connectivity passed.
+Test 2: Node Readiness... All nodes are Ready.
+Test 3: Workload Readiness... Workload is available.
+All Validation Tests passed successfully for {{TEMPLATE_NAME}}!
+```
+
+---
+
+## Template Inputs
+
+| Variable | Description | Default |
+|---|---|---|
+| `project_id` | GCP project ID | required |
+| `region` | GCP region | `us-central1` |
+| `cluster_name` | GKE cluster name | `{{SHORT_NAME}}-tf` |
+| `network_name` | VPC network name | `{{SHORT_NAME}}-tf-vpc` |
+| `subnet_name` | Subnet name | `{{SHORT_NAME}}-tf-subnet` |

--- a/agent-infra/scaffolds/template.template.yaml
+++ b/agent-infra/scaffolds/template.template.yaml
@@ -13,4 +13,4 @@ gcpServices:                          # List of GCP services provisioned by this
   # - GPU Node Pool
 kccSupported: true                    # Set to false if .kcc-unsupported file is present.
 estimatedMonthlyCost: "~${{COST}}"   # Rough estimate. E.g. "~$150" or "~$800 (GPU)"
-issueNumber: {{ISSUE_NUMBER}}         # GitHub issue number that requested this template.
+issueNumber: "{{ISSUE_NUMBER}}"       # GitHub issue number that requested this template.

--- a/agent-infra/scaffolds/template.template.yaml
+++ b/agent-infra/scaffolds/template.template.yaml
@@ -1,0 +1,16 @@
+# Template metadata — required in every template directory.
+# local-lint.sh enforces: shortName present, ≤ 20 chars.
+# ci-post-merge.yml reads this to build the template index table.
+
+shortName: "{{SHORT_NAME}}"          # ≤ 20 chars, lowercase, hyphens only. Used in GCP resource names.
+displayName: "{{DISPLAY_NAME}}"      # Human-readable name for the index table.
+description: "{{ONE_LINE_DESCRIPTION}}"
+gcpServices:                          # List of GCP services provisioned by this template.
+  - GKE
+  # - Cloud SQL
+  # - GCS
+  # - Pub/Sub
+  # - GPU Node Pool
+kccSupported: true                    # Set to false if .kcc-unsupported file is present.
+estimatedMonthlyCost: "~${{COST}}"   # Rough estimate. E.g. "~$150" or "~$800 (GPU)"
+issueNumber: {{ISSUE_NUMBER}}         # GitHub issue number that requested this template.

--- a/agent-infra/scaffolds/validate.template.sh
+++ b/agent-infra/scaffolds/validate.template.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# validate.sh scaffold — copy to your template and complete ALL sections.
+#
+# CRITICAL: This script must PROVE the workload works end-to-end.
+# "Deployment Available" is NOT sufficient. You MUST add at least one of:
+#   - curl/wget to an HTTP endpoint and verify a non-empty/200 response
+#   - kubectl exec into a pod and run a meaningful command (psql, redis-cli, etc.)
+#   - A custom resource status check (RayCluster Ready, LocalQueue Active, etc.)
+#
+# CI will run this script after deploying the template. If it exits 0 without
+# actually verifying the workload, the template is considered broken.
+#
+# PLACEHOLDERS to replace:
+#   {{TEMPLATE_NAME}}  — human-readable name, e.g. "GKE KubeRay + Kueue"
+#   {{SHORT_NAME}}     — shortName from template.yaml, e.g. "gke-kuberay-kueue"
+#   {{APP_LABEL}}      — label selector for your workload, e.g. "app.kubernetes.io/name=ray-head"
+#   {{NAMESPACE}}      — workload namespace, e.g. "ray-system"
+
+set -euo pipefail
+
+echo "=== Validation: {{TEMPLATE_NAME}} ==="
+
+PROJECT_ID="${PROJECT_ID:-gca-gke-2025}"
+CLUSTER_NAME="${CLUSTER_NAME:-{{SHORT_NAME}}-tf}"
+REGION="${REGION:-us-central1}"
+NAMESPACE="${NAMESPACE:-{{NAMESPACE}}}"
+
+# Isolate kubeconfig — never pollute the runner's default context
+export KUBECONFIG
+KUBECONFIG=$(mktemp)
+trap 'rm -f "$KUBECONFIG"' EXIT
+
+# ── 1. Cluster Connectivity ───────────────────────────────────────────────────
+echo "--- Test 1: Cluster Connectivity ---"
+gcloud container clusters get-credentials "${CLUSTER_NAME}" \
+  --region "${REGION}" --project "${PROJECT_ID}"
+kubectl cluster-info
+kubectl get nodes -o wide
+echo "PASS: Cluster is reachable."
+
+# ── 2. Node Readiness ─────────────────────────────────────────────────────────
+echo "--- Test 2: Node Readiness ---"
+kubectl wait nodes --all --for=condition=Ready --timeout=10m
+echo "PASS: All nodes are Ready."
+
+# ── 3. Workload Deployment Readiness ─────────────────────────────────────────
+# Replace {{APP_LABEL}} with the label your Deployment/StatefulSet uses.
+# Use a label that works for BOTH the Helm path and the KCC path.
+echo "--- Test 3: Workload Deployment Readiness ---"
+kubectl wait deployment \
+  -l "{{APP_LABEL}}" \
+  -n "${NAMESPACE}" \
+  --for=condition=available \
+  --timeout=30m
+kubectl get pods -n "${NAMESPACE}" -l "{{APP_LABEL}}" -o wide
+echo "PASS: Workload Deployment is Available."
+
+# ── 4. Pod Log Sanity Check ───────────────────────────────────────────────────
+# Verify the workload started cleanly — no crash-loops hiding in "Available".
+echo "--- Test 4: Pod Log Sanity ---"
+POD=$(kubectl get pod -n "${NAMESPACE}" -l "{{APP_LABEL}}" \
+  --field-selector=status.phase=Running \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+if [ -z "$POD" ]; then
+  echo "ERROR: No Running pod found matching label {{APP_LABEL}} in namespace ${NAMESPACE}"
+  kubectl get events -n "${NAMESPACE}" --sort-by='.lastTimestamp' | tail -20
+  exit 1
+fi
+echo "Checking logs for pod $POD (last 20 lines)..."
+kubectl logs "$POD" -n "${NAMESPACE}" --tail=20
+echo "PASS: Pod is running and producing logs."
+
+# ── 5. Workload Functional Verification ──────────────────────────────────────
+# THIS SECTION IS MANDATORY — pick the pattern that matches your workload.
+# Remove the patterns that don't apply. Leaving this section empty = CI failure.
+echo "--- Test 5: Workload Functional Verification ---"
+
+# ── PATTERN A: HTTP Service (LoadBalancer or Gateway) ────────────────────────
+# Use this for any workload that exposes an HTTP/HTTPS endpoint.
+#
+# SERVICE_IP=""
+# for i in $(seq 1 20); do
+#   SERVICE_IP=$(kubectl get svc -n "${NAMESPACE}" -l "{{APP_LABEL}}" \
+#     -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+#   [ -n "$SERVICE_IP" ] && break
+#   echo "Waiting for LoadBalancer IP (attempt $i/20)..."
+#   sleep 30
+# done
+# if [ -z "$SERVICE_IP" ]; then
+#   echo "ERROR: LoadBalancer IP not assigned after 10 minutes"
+#   kubectl get svc -n "${NAMESPACE}"
+#   exit 1
+# fi
+# echo "LoadBalancer IP: ${SERVICE_IP}"
+# for i in $(seq 1 12); do
+#   HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+#     --connect-timeout 5 --max-time 15 "http://${SERVICE_IP}:80/" || echo "000")
+#   if [[ "$HTTP_STATUS" =~ ^(200|201|204|301|302)$ ]]; then
+#     echo "PASS: Endpoint http://${SERVICE_IP}:80/ returned HTTP $HTTP_STATUS"
+#     break
+#   fi
+#   echo "HTTP $HTTP_STATUS — retrying (attempt $i/12)..."
+#   sleep 30
+#   [ $i -eq 12 ] && { echo "ERROR: Endpoint failed after 12 attempts"; exit 1; }
+# done
+
+# ── PATTERN B: exec-based check (DB, cache, queue) ───────────────────────────
+# Use this for Cloud SQL, Redis, Kafka, Spanner client, etc.
+#
+# kubectl exec -n "${NAMESPACE}" "$POD" -- \
+#   psql -h localhost -U app -c "SELECT 1" > /dev/null \
+#   && echo "PASS: Database is accepting connections."
+#
+# kubectl exec -n "${NAMESPACE}" "$POD" -- \
+#   redis-cli ping | grep -q PONG \
+#   && echo "PASS: Redis is responding."
+
+# ── PATTERN C: Custom resource readiness (operator-managed CRDs) ──────────────
+# Use this for templates that deploy operator-managed resources where the operator
+# exposes a Ready/Active condition on a custom resource.
+# Replace the resource kind and condition with whatever your operator exposes.
+#
+# Generic CRD wait pattern:
+# kubectl wait <resource-kind> --all -n "${NAMESPACE}" \
+#   --for=condition=Ready --timeout=20m \
+#   && echo "PASS: <Resource> is Ready."
+#
+# Examples by technology:
+#   KubeRay:  kubectl wait raycluster --all -n "${NAMESPACE}" --for=condition=Ready --timeout=20m
+#   Kueue:    kubectl wait localqueue --all -n "${NAMESPACE}" --for=condition=Active --timeout=5m
+#   Argo:     kubectl wait workflow --all -n "${NAMESPACE}" --for=condition=Completed --timeout=20m
+#   Knative:  kubectl wait ksvc --all -n "${NAMESPACE}" --for=condition=Ready --timeout=10m
+#   Kafka:    kubectl wait kafka --all -n "${NAMESPACE}" --for=condition=Ready --timeout=15m
+#
+# Submit a test batch job and verify it completes (generic pattern):
+# TEST_JOB="validate-$(date +%s)"
+# kubectl create job "$TEST_JOB" --image=busybox -n "${NAMESPACE}" \
+#   -- sh -c "echo workload-ok"
+# kubectl wait job "$TEST_JOB" -n "${NAMESPACE}" \
+#   --for=condition=Complete --timeout=10m \
+#   && echo "PASS: Test job completed."
+# kubectl delete job "$TEST_JOB" -n "${NAMESPACE}" --ignore-not-found
+
+# ── TODO: IMPLEMENT ONE OF THE PATTERNS ABOVE ────────────────────────────────
+# Do NOT leave this section empty. A validate.sh that only reaches this line
+# without actually verifying the workload is a broken validate.sh.
+echo "ERROR: validate.sh is incomplete — Test 5 (Workload Functional Verification) not implemented."
+echo "Copy one of the patterns above and adapt it to this template's workload."
+exit 1
+# ── END FUNCTIONAL VERIFICATION ──────────────────────────────────────────────
+
+echo "=== All Validation Tests PASSED for {{TEMPLATE_NAME}} ==="

--- a/templates/basic-gke-hello-world/template.yaml
+++ b/templates/basic-gke-hello-world/template.yaml
@@ -1,0 +1,13 @@
+shortName: "gke-basic"
+displayName: "Basic GKE Hello World"
+description: >
+  A minimal GKE Standard cluster deploying a Hello World web service via
+  Helm (terraform-helm path) and Config Connector (config-connector path).
+  Exposes the workload via a LoadBalancer Service and validates via HTTP endpoint.
+gcpServices:
+  - GKE
+  - VPC
+  - Cloud Load Balancing
+kccSupported: true
+estimatedMonthlyCost: "$75–$120 (e2-medium × 2 nodes)"
+issueNumber: 0

--- a/templates/enterprise-gke/template.yaml
+++ b/templates/enterprise-gke/template.yaml
@@ -1,0 +1,11 @@
+shortName: "enterprise-gke"
+displayName: "Enterprise GKE Cluster"
+description: "Enterprise-grade GKE with Binary Authorization, Workload Identity, and hardened security controls"
+gcpServices:
+  - GKE
+  - VPC
+  - Binary Authorization
+  - Cloud Armor
+kccSupported: true
+estimatedMonthlyCost: "~$300"
+issueNumber: 0

--- a/templates/gke-fqdn-egress-security/template.yaml
+++ b/templates/gke-fqdn-egress-security/template.yaml
@@ -1,0 +1,10 @@
+shortName: "gke-fqdn-egress"
+displayName: "GKE Zero-Trust FQDN Egress"
+description: "Zero-trust egress security with FQDN network policies for controlling AI API traffic from GKE"
+gcpServices:
+  - GKE
+  - VPC
+  - Cloud DNS
+kccSupported: true
+estimatedMonthlyCost: "~$150"
+issueNumber: 0

--- a/templates/gke-inference-fuse-cache/template.yaml
+++ b/templates/gke-inference-fuse-cache/template.yaml
@@ -1,0 +1,10 @@
+shortName: "gke-fuse-cache"
+displayName: "GKE GCS FUSE Inference Cache"
+description: "High-performance AI inference with GCS FUSE + Local SSD caching for fast model loading on L4 GPUs"
+gcpServices:
+  - GKE
+  - GCS
+  - GPU Node Pool
+kccSupported: true
+estimatedMonthlyCost: "~$600 (L4 GPU)"
+issueNumber: 0

--- a/templates/gke-topology-aware-routing/template.yaml
+++ b/templates/gke-topology-aware-routing/template.yaml
@@ -1,0 +1,9 @@
+shortName: "gke-topo-routing"
+displayName: "GKE Topology-Aware Routing"
+description: "Minimize cross-zone egress costs using Topology-Aware Routing hints in multi-zonal GKE clusters"
+gcpServices:
+  - GKE
+  - VPC
+kccSupported: true
+estimatedMonthlyCost: "~$150"
+issueNumber: 0

--- a/templates/latest-gke-features/template.yaml
+++ b/templates/latest-gke-features/template.yaml
@@ -1,0 +1,10 @@
+shortName: "latest-gke-feat"
+displayName: "Latest GKE Features"
+description: "Showcase of latest GKE features: Gateway API, Node Auto-Provisioning, and modern workload patterns"
+gcpServices:
+  - GKE
+  - VPC
+  - Cloud Load Balancing
+kccSupported: true
+estimatedMonthlyCost: "~$200"
+issueNumber: 0

--- a/templates/test-kcc-skip/template.yaml
+++ b/templates/test-kcc-skip/template.yaml
@@ -1,0 +1,9 @@
+shortName: "test-kcc-skip"
+displayName: "Test KCC Skip"
+description: "Test template verifying the KCC-unsupported skip mechanism in CI validation"
+gcpServices:
+  - GKE
+  - VPC
+kccSupported: false
+estimatedMonthlyCost: "~$100"
+issueNumber: 0


### PR DESCRIPTION
## Summary

Establishes the full agent context layer required before OpenClaw can operate autonomously end-to-end.

- **`.gemini/SUCCESS.md`** — canonical 7-checkpoint definition of done the agent reads first
- **`.gemini/user-instructions.json`** — expanded to 15 correctness rules
- **`GEMINI.md`** — updated with OpenClaw orchestration docs (watcher.sh, deploy.sh, SUCCESS.md pointer)
- **`agent-infra/kcc-capabilities.yaml`** — KCC unsupported feature registry
- **`agent-infra/scaffolds/`** — validate.sh, README, template.yaml scaffolds (validate.sh Test 5 exits 1 by default, forcing functional verification)
- **`agent-infra/local-lint.sh`** — template.yaml existence + shortName length + KCC registry checks
- **`templates/basic-gke-hello-world/template.yaml`** — was missing, blocked lint on the reference template
- **Concurrency fix** — sandbox-validation TF + KCC share group `validation-$ref` to prevent race on `.validated` writes

## This is a prerequisite for running Epic #122

No template code changed. All workflow logic is unchanged from main except the concurrency group rename.

Closes (precondition for) #122