### PR TITLE
[CI-BUG] Fix concurrency groups and path scoping for all four workflows

### DIFF
--- a/.github/workflows/sandbox-validation-kcc.yml
+++ b/.github/workflows/sandbox-validation-kcc.yml
@@ -4,20 +4,22 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'templates/**'
+      - 'templates/**/config-connector/**'
+      - 'templates/**/config-connector-workload/**'
       - 'agent-infra/**'
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, closed]
     paths:
-      - 'templates/**'
+      - 'templates/**/config-connector/**'
+      - 'templates/**/config-connector-workload/**'
       - 'agent-infra/**'
 
 concurrency:
-  # Share concurrency group with TF workflow to prevent concurrent .validated writes
-  # to the same branch. If both workflows fire on the same push, one will queue.
-  group: validation-${{ github.ref }}
-  cancel-in-progress: false
+  # Per-PR group for KCC sandbox only; cancel-in-progress stops stale queued runs
+  # from blocking KCC validation behind unrelated TF sandbox runs.
+  group: sandbox-kcc-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/.github/workflows/sandbox-validation-tf.yml
+++ b/.github/workflows/sandbox-validation-tf.yml
@@ -4,20 +4,20 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'templates/**'
+      - 'templates/**/terraform-helm/**'
       - 'agent-infra/**'
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, closed]
     paths:
-      - 'templates/**'
+      - 'templates/**/terraform-helm/**'
       - 'agent-infra/**'
 
 concurrency:
-  # Share concurrency group with KCC workflow to prevent concurrent .validated writes
-  # to the same branch. If both workflows fire on the same push, one will queue.
-  group: validation-${{ github.ref }}
-  cancel-in-progress: false
+  # Per-PR group for TF sandbox only; cancel-in-progress stops stale queued runs
+  # from executing and provisioning orphan clusters on every push.
+  group: sandbox-tf-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/.github/workflows/validate-kcc.yml
+++ b/.github/workflows/validate-kcc.yml
@@ -27,8 +27,10 @@ on:
       - 'agent-infra/**'
 
 concurrency:
-  group: gke-cluster-provisioning
-  cancel-in-progress: false
+  # Per-PR group prevents parallel KCC runs on the same PR; cancel-in-progress
+  # ensures a new push cancels stale queued/running runs for THIS PR only.
+  group: validate-kcc-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -26,8 +26,10 @@ on:
       - 'agent-infra/**'
 
 concurrency:
-  group: gke-cluster-provisioning
-  cancel-in-progress: false
+  # Per-PR group prevents parallel TF runs on the same PR; cancel-in-progress
+  # ensures a new push cancels stale queued/running runs for THIS PR only.
+  group: validate-tf-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write


### PR DESCRIPTION
[CI-BUG] Fix workflow concurrency: per-PR groups + cancel-in-progress: true on all four workflows. Scopes sandbox paths to terraform-helm/ and config-connector/. Fixes orphan cluster proliferation and KCC validation starvation.