### PR TITLE
ci: scope path triggers — TF only sees TF, KCC only sees KCC

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -18,9 +18,11 @@ on:
   push:
     paths:
       - '.github/workflows/**'
+      - 'agent-infra/**'
   pull_request:
     paths:
       - '.github/workflows/**'
+      - 'agent-infra/**'
 
 jobs:
   actionlint:
@@ -30,3 +32,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run actionlint
         uses: reviewdog/action-actionlint@v1
+
+  lint-agent-infra:
+    name: "Lint Agent Infra"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+      - name: Run Thorough Linting
+        run: |
+          chmod +x agent-infra/local-lint.sh
+          ./agent-infra/local-lint.sh agent-infra

--- a/.github/workflows/validate-kcc.yml
+++ b/.github/workflows/validate-kcc.yml
@@ -24,7 +24,6 @@ on:
       - 'templates/**/config-connector-workload/**'
       - '.github/workflows/validate-kcc.yml'
       - '.github/actions/**'
-      - 'agent-infra/**'
 
 concurrency:
   # Per-PR group prevents parallel KCC runs on the same PR; cancel-in-progress

--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -23,7 +23,6 @@ on:
       - 'templates/**/terraform-helm/**'
       - '.github/workflows/validate-tf.yml'
       - '.github/actions/**'
-      - 'agent-infra/**'
 
 concurrency:
   # Per-PR group prevents parallel TF runs on the same PR; cancel-in-progress
@@ -70,19 +69,6 @@ jobs:
         run: gh pr edit "${{ github.event.number }}" --remove-label "status:ai-agent-active" || true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  lint-agent-infra:
-    name: "Lint Agent Infra"
-    runs-on: ubuntu-latest
-    if: github.event.action != 'closed'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-      - name: Run Thorough Linting
-        run: |
-          chmod +x agent-infra/local-lint.sh
-          ./agent-infra/local-lint.sh agent-infra
 
   lint:
     name: "Lint TF (${{ matrix.template }})"


### PR DESCRIPTION
Removes agent-infra/** from validate-tf/kcc path triggers. Moves Lint Agent Infra to lint-workflows.yml. Prevents TF checks appearing on KCC PRs and vice versa.