### PR TITLE
ci: consolidate cleanup to single K3s CronJob

### DIFF
--- a/.github/workflows/cleanup-orphans.yml
+++ b/.github/workflows/cleanup-orphans.yml
@@ -1,9 +1,9 @@
 name: Cleanup Orphaned Infrastructure
+# ⚠️  PRIMARY CLEANUP IS THE K3s CRONJOB (openclaw-cleanup, every 5 min).
+# This workflow is EMERGENCY ONLY. The CronJob has PROTECTED_CLUSTERS enforcement.
+# If you must run this, verify the filter below excludes all permanent clusters.
 on:
-  # Schedule removed — cleanup is now handled by the openclaw-cleanup K8s CronJob
-  # which runs every 5 minutes and is not subject to GitHub Actions scheduler delays.
-  # Keep workflow_dispatch for emergency manual runs only.
-  workflow_dispatch: # Manual emergency cleanup
+  workflow_dispatch: # Emergency manual cleanup only
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/validate-kcc.yml
+++ b/.github/workflows/validate-kcc.yml
@@ -246,18 +246,6 @@ jobs:
             gh pr edit "${{ github.event.number }}" --add-label "status:ai-agent-active"
           fi
 
-  cleanup-orphans:
-    name: Cleanup Orphans
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ env.WIF_PROVIDER }}
-          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
-      - name: Run Cleanup Script
-        run: |
-          chmod +x agent-infra/cleanup-resources.sh
-          ./agent-infra/cleanup-resources.sh
+  # Cleanup is handled by the openclaw-cleanup K3s CronJob (every 5 min).
+  # Removed from CI to consolidate into a single cleanup path with proper
+  # PROTECTED_CLUSTERS enforcement.

--- a/.github/workflows/validate-tf.yml
+++ b/.github/workflows/validate-tf.yml
@@ -249,18 +249,6 @@ jobs:
             gh pr edit "${{ github.event.number }}" --add-label "status:ai-agent-active"
           fi
 
-  cleanup-orphans:
-    name: Cleanup Orphans
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ env.WIF_PROVIDER }}
-          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
-      - name: Run Cleanup Script
-        run: |
-          chmod +x agent-infra/cleanup-resources.sh
-          ./agent-infra/cleanup-resources.sh
+  # Cleanup is handled by the openclaw-cleanup K3s CronJob (every 5 min).
+  # Removed from CI to consolidate into a single cleanup path with proper
+  # PROTECTED_CLUSTERS enforcement.


### PR DESCRIPTION
Removes CI cleanup paths that kept deleting gemma4-inference. Single cleanup via K3s CronJob with PROTECTED_CLUSTERS.