### PR TITLE
fix: address issue #257

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -53,7 +53,6 @@ runs:
         CHANGED_FILES=$(git diff --name-only "$BASE" "$DIFF_HEAD")
         DIRS=$(echo "$CHANGED_FILES" \
           | grep '^templates/' \
-          | grep -v '\.md$' \
           | awk -F/ '{print $1"/"$2}' \
           | sort -u || true)
         

--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -300,7 +300,7 @@ jobs:
           
           git config user.name "codebot-sfle"
           git config user.email "codebot-sfle@sfle.ca"
-          git add templates/**/.validated templates/**/README.md
+          git add templates/
+          git status
           git commit -m "ci: bulk validate templates [skip ci]" || true
           git push origin main || (git pull --rebase origin main && git push origin main)
-ush origin main)

--- a/agent-infra/local-lint.sh
+++ b/agent-infra/local-lint.sh
@@ -141,9 +141,10 @@ KCCPY
     echo "ERROR: Template '${template_name}' README.md is missing CI validation record marker"
     exit 1
   fi
-  # Mandate: CI marker must be at the end of the file (within last 5 lines)
-  if ! tail -n 5 "${template}/README.md" | grep -q "<!-- CI: validation record"; then
-    echo "ERROR: Template '${template_name}' README.md has CI marker but it's not at the end of the file"
+  # Mandate: CI marker must be near the end of the file (within last 20 lines)
+  # This accommodates the appended validation record table.
+  if ! tail -n 20 "${template}/README.md" | grep -q "<!-- CI: validation record"; then
+    echo "ERROR: Template '${template_name}' README.md has CI marker but it's not near the end of the file"
     exit 1
   fi
   # Mandate: No unreplaced placeholders


### PR DESCRIPTION
Closes #257. Repairs the CI/CD pipeline and updates linting rules to allow validation records in READMEs.