### PR TITLE
feat: implement online-boutique-gke template (closes #320)

### DIFF
--- a/templates/online-boutique-gke/config-connector/cluster.yaml
+++ b/templates/online-boutique-gke/config-connector/cluster.yaml
@@ -1,0 +1,39 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: ob-kcc
+  namespace: forge-management
+  labels:
+    project: gcp-template-forge
+    template: online-boutique-gke
+  annotations:
+    cnrm.cloud.google.com/project-id: gca-gke-2025
+    cnrm.cloud.google.com/remove-default-node-pool: "true"
+spec:
+  location: us-central1
+  initialNodeCount: 1
+  networkRef:
+    name: ob-kcc-vpc
+  subnetworkRef:
+    name: ob-kcc-subnet
+  ipAllocationPolicy:
+    clusterSecondaryRangeName: pods
+    servicesSecondaryRangeName: services
+  workloadIdentityConfig:
+    workloadPool: gca-gke-2025.svc.id.goog
+  releaseChannel:
+    channel: REGULAR

--- a/templates/online-boutique-gke/config-connector/network.yaml
+++ b/templates/online-boutique-gke/config-connector/network.yaml
@@ -1,0 +1,48 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: ob-kcc-vpc
+  namespace: forge-management
+  labels:
+    project: gcp-template-forge
+    template: online-boutique-gke
+  annotations:
+    cnrm.cloud.google.com/project-id: gca-gke-2025
+spec:
+  autoCreateSubnetworks: false
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: ob-kcc-subnet
+  namespace: forge-management
+  labels:
+    project: gcp-template-forge
+    template: online-boutique-gke
+  annotations:
+    cnrm.cloud.google.com/project-id: gca-gke-2025
+spec:
+  ipCidrRange: 10.0.0.0/16
+  region: us-central1
+  networkRef:
+    name: ob-kcc-vpc
+  privateIpGoogleAccess: true
+  secondaryIpRange:
+    - rangeName: pods
+      ipCidrRange: 10.1.0.0/16
+    - rangeName: services
+      ipCidrRange: 10.2.0.0/20

--- a/templates/online-boutique-gke/config-connector/nodepool.yaml
+++ b/templates/online-boutique-gke/config-connector/nodepool.yaml
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerNodePool
+metadata:
+  name: ob-kcc-pool
+  namespace: forge-management
+  labels:
+    project: gcp-template-forge
+    template: online-boutique-gke
+  annotations:
+    cnrm.cloud.google.com/project-id: gca-gke-2025
+spec:
+  location: us-central1
+  clusterRef:
+    name: ob-kcc
+  nodeCount: 2
+  nodeLocations:
+    - us-central1-a
+    - us-central1-b
+    - us-central1-c
+  nodeConfig:
+    machineType: e2-standard-4
+    diskSizeGb: 100
+    diskType: pd-standard
+    oauthScopes:
+      - https://www.googleapis.com/auth/cloud-platform
+    workloadMetadataConfig:
+      mode: GKE_METADATA
+    labels:
+      project: gcp-template-forge
+      template: online-boutique-gke
+  autoscaling:
+    minNodeCount: 1
+    maxNodeCount: 5


### PR DESCRIPTION
Closes #320

## Summary
- Template: `online-boutique-gke`
- Parent Epic: #318
- Path: config-connector