### PR TITLE
feat: implement gke-custom-compute-c template (closes #387)

### DIFF
--- a/templates/gke-custom-compute-c/README.md
+++ b/templates/gke-custom-compute-c/README.md
@@ -1,37 +1,169 @@
-# GKE Custom Compute Template
+# GKE Custom Compute
 
-This template provisions a GKE Standard cluster with a custom compute node pool using custom machine types (e.g. `e2-custom-4-8192`), and deploys a robust sample workload.
+> A GKE Standard cluster with custom compute node pools configured with custom machine types (e.g. e2-custom-4-8192) and standard workloads.
 
 ## Architecture
 
-- **VPC & Subnets**: A standalone VPC with subnetwork containing secondary ranges for Pod and Service IPs.
-- **GKE Cluster**: A zonal Standard container cluster with deletion protection deactivated.
-- **Custom Compute Node Pool**: A custom node pool using `e2-custom-4-8192` machine types.
-- **Helm Workload**: Deploys an HTTP web server with LoadBalancer service, readiness, and liveness checks.
+This template provisions:
 
-## Inputs / Requirements
+- **VPC Network** — Standalone VPC with subnetwork containing secondary ranges for Pod and Service IPs in `us-central1`
+- **GKE Cluster** — zonal Standard container cluster (`gke-custom-compute-c`) with deletion protection deactivated
+- **Workload** — Deploys an HTTP web server with LoadBalancer service, readiness, and liveness checks.
 
-The following variables are expected to be injected dynamically by CI:
+### Resource Naming
 
-- `project_id`: GCP Project ID.
-- `region`: GCP Region.
-- `zone`: GCP Zone.
-- `cluster_name`: GKE Cluster name.
-- `network_name`: VPC Network name.
-- `subnet_name`: Subnetwork name.
-- `uid_suffix`: Last 6 digits of CI run ID.
-- `service_account`: Service account used by GKE node pool.
+| Resource | Terraform + Helm | Config Connector |
+|---|---|---|
+| GKE Cluster | `gke-custom-compute-c-<uid>-tf` | `gke-custom-compute-c-<uid>-kcc` |
+| VPC Network | `gke-custom-compute-c-<uid>-tf-vpc` | `gke-custom-compute-c-<uid>-kcc-vpc` |
+| Subnet | `gke-custom-compute-c-<uid>-tf-subnet` | `gke-custom-compute-c-<uid>-kcc-subnet` |
 
-## Inputs
+### Estimated Cost
 
-| Name | Description | Default |
-|------|-------------|---------|
-| project_id | The GCP Project ID | n/a |
-| region | The GCP Region | us-central1 |
-| zone | The GCP Zone | us-central1-a |
-| cluster_name | The name of the GKE cluster | n/a |
-| network_name | The VPC network name | n/a |
-| subnet_name | The subnet name | n/a |
-| uid_suffix | The last 6 digits of the CI run ID | n/a |
-| service_account | The CI WIF service account | n/a |
+| Resource | Monthly Estimate |
+|---|---|
+| GKE Cluster (control plane) | ~$75 |
+| Custom Compute Node Pool (2x e2-custom-4-8192) | ~$70 |
+| LoadBalancer & Networking | ~$18 |
+| **Total** | **~$163** |
 
+*Estimates based on sustained use in us-central1. GPU templates incur additional on-demand charges.*
+
+---
+
+## Deployment Paths
+
+This template supports two deployment paths that provision equivalent infrastructure.
+
+### Path 1: Terraform + Helm
+
+**Prerequisites:** `terraform` ≥ 1.5, `helm` ≥ 3.10, `kubectl`, `gcloud` with ADC configured.
+
+```bash
+cd templates/gke-custom-compute-c/terraform-helm
+
+# Initialize with GCS backend (or use local state for testing)
+terraform init \
+  -backend-config="bucket=YOUR_TF_STATE_BUCKET" \
+  -backend-config="prefix=gke-custom-compute-c/terraform-helm"
+
+# Review the plan
+terraform plan \
+  -var="project_id=YOUR_PROJECT_ID" \
+  -var="region=us-central1"
+
+# Apply (provisions GKE cluster and supporting infrastructure)
+terraform apply \
+  -var="project_id=YOUR_PROJECT_ID" \
+  -var="region=us-central1"
+
+# Get cluster credentials
+CLUSTER_NAME=$(terraform output -raw cluster_name)
+REGION=$(terraform output -raw cluster_location)
+gcloud container clusters get-credentials "${CLUSTER_NAME}" --region "${REGION}"
+
+# Deploy the workload via Helm
+helm upgrade --install release ./workload --wait --timeout=30m
+
+# Verify
+kubectl get nodes
+kubectl get pods -A
+```
+
+**Cleanup:**
+```bash
+helm uninstall release
+terraform destroy -var="project_id=YOUR_PROJECT_ID" -var="region=us-central1"
+```
+
+---
+
+### Path 2: Config Connector (KCC)
+
+**Prerequisites:** A running GKE cluster with Config Connector installed. See the
+[KCC installation guide](https://cloud.google.com/config-connector/docs/how-to/install-upgrade-uninstall).
+The `forge-management` namespace must have a `ConfigConnectorContext` pointing to a
+service account with `roles/container.admin` and `roles/compute.networkAdmin`.
+
+```bash
+cd templates/gke-custom-compute-c/config-connector
+
+# Apply the GCP infrastructure manifests
+kubectl apply -n forge-management -f .
+
+# Wait for all resources to be Ready (GKE cluster takes ~10 minutes)
+kubectl wait -n forge-management --for=condition=Ready --all \
+  --timeout=3600s -f .
+
+# Get cluster credentials (once ContainerCluster is Ready)
+CLUSTER_NAME=$(kubectl get containerclusters.container.cnrm.cloud.google.com \
+  -n forge-management -l "template=gke-custom-compute-c" \
+  -o jsonpath='{.items[0].metadata.name}')
+LOCATION=$(kubectl get containerclusters.container.cnrm.cloud.google.com \
+  -n forge-management -l "template=gke-custom-compute-c" \
+  -o jsonpath='{.items[0].spec.location}')
+gcloud container clusters get-credentials "${CLUSTER_NAME}" --region "${LOCATION}"
+
+# Deploy the workload
+kubectl apply -n default -f ../config-connector-workload/
+
+# Verify
+kubectl get nodes
+kubectl get pods -A
+```
+
+**Cleanup:**
+```bash
+kubectl delete -n default -f ../config-connector-workload/
+kubectl delete -n forge-management -f . --wait=true --timeout=900s
+```
+
+---
+
+## Verification
+
+After deploying with either path, run the validation script to confirm end-to-end functionality:
+
+```bash
+export PROJECT_ID="YOUR_PROJECT_ID"
+export CLUSTER_NAME="<cluster-name-from-outputs>"
+export REGION="us-central1"
+chmod +x templates/gke-custom-compute-c/validate.sh
+./templates/gke-custom-compute-c/validate.sh
+```
+
+Expected output:
+```
+Test 1: Cluster Connectivity... Connectivity passed.
+Test 2: Node Readiness... All nodes are Ready.
+Test 3: Workload Readiness... Workload is available.
+All Validation Tests passed successfully for GKE Custom Compute!
+```
+
+---
+
+## Template Inputs
+
+| Variable | Description | Default |
+|---|---|---|
+| `project_id` | GCP project ID | required |
+| `region` | GCP region | `us-central1` |
+| `cluster_name` | GKE cluster name | `gke-custom-compute-c-tf` |
+| `network_name` | VPC network name | `gke-custom-compute-c-tf-vpc` |
+| `subnet_name` | Subnet name | `gke-custom-compute-c-tf-subnet` |
+
+<!-- CI: validation record appended here by ci-post-merge.yml — do not edit below this line manually -->
+
+## Validation Record
+
+|  | Terraform + Helm | Config Connector |
+| --- | --- | --- |
+| **Status** | pending | pending |
+| **Date** | n/a | n/a |
+| **Duration** | n/a | n/a |
+| **Region** | us-central1 | us-central1 (KCC cluster) |
+| **Zones** | - | forge-management namespace |
+| **Cluster** | -- | krmapihost-kcc-instance |
+| **Agent tokens** | - | (shared session) |
+| **Estimated cost** | - | -- |
+| **Commit** | n/a | n/a |

--- a/templates/gke-custom-compute-c/terraform-helm/.terraform.lock.hcl
+++ b/templates/gke-custom-compute-c/terraform-helm/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.33.0"
+  constraints = ">= 4.40.0"
+  hashes = [
+    "h1:AtuVYxtxBEHMS9o/9HR2bg9Z/Ta4MLckXhSOwX8PWFs=",
+    "zh:10620bf55734d05701852dbbd55aa151860cbaf672001222c29ee93ec02d062e",
+    "zh:1ca1a3829a1fdbbce17a540d2be63b1529e46debdb8dbf0057facc992110ff38",
+    "zh:5f3a1b7b1feeafd4d4677b3936a1f6a66a02bf9844b6949e876ee64d0573a73a",
+    "zh:63c513a92a4842c53adbcd0103646e6828ce412f5a66efafaa0c79bc0dbe95de",
+    "zh:862812a0185d3467eae29f8923eebcecdcd50f9d1f0ec543004eaea96105ddc9",
+    "zh:9bf2df9ece0ade7c3fd57f0d164fb5c05211adfbb11315cf78d637bdb21c33cf",
+    "zh:9c378b72733dbe51ed81c81bb2c1902668d8f833d0d352d5fc2201571cffc6fe",
+    "zh:c17f96906e616b8e78c106884cf1c6621a5bdf69026f5debbddcc4b11af7b62c",
+    "zh:c410df582884bb3b8bc08a27b223783a541f4bd8223d025918545ae5435dcb10",
+    "zh:e68d159165213cd7f9c24a3d12a2141879126d6253f58587bb88de648fc6fbc9",
+    "zh:f13d4e191bb36979c3d9a40d8e18119743e8951bcb6fb7c456c0d94ea548f574",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/templates/gke-custom-compute-c/terraform-helm/outputs.tf
+++ b/templates/gke-custom-compute-c/terraform-helm/outputs.tf
@@ -18,3 +18,9 @@ output "endpoint" {
   description = "The GKE cluster endpoint."
   sensitive   = true
 }
+
+output "cluster_location" {
+  value       = google_container_cluster.primary.location
+  description = "The GKE cluster location (zone or region)."
+}
+


### PR DESCRIPTION
Closes #387

## Summary
- Template: `gke-custom-compute-c`
- Parent Epic: #387
- Path: terraform-helm