### PR TITLE
fix(workflows): add if-conditions to post-merge matrix validation jobs

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -64,6 +64,7 @@ jobs:
   validate-tf-helm:
     name: Validate TF+Helm (${{ matrix.template }})
     needs: detect-changes
+    if: needs.detect-changes.outputs.tf_templates != '[]' && needs.detect-changes.outputs.tf_templates != ''
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:
@@ -179,6 +180,7 @@ jobs:
   validate-kcc:
     name: Validate KCC (${{ matrix.template }})
     needs: detect-changes
+    if: needs.detect-changes.outputs.kcc_templates != '[]' && needs.detect-changes.outputs.kcc_templates != ''
     runs-on: ubuntu-latest
     timeout-minutes: 120
     strategy:


### PR DESCRIPTION
This PR adds if-conditions to both validate-tf-helm and validate-kcc jobs in ci-post-merge.yml to prevent GitHub Actions from failing at startup when the changed templates list for either TF or KCC is empty.