### PR TITLE
Draft: [TF] Validate gke-k8s-rbac-manager (Re-run 2)

### DIFF
--- a/templates/gke-k8s-rbac-manager/trigger.txt
+++ b/templates/gke-k8s-rbac-manager/trigger.txt
@@ -1,1 +1,1 @@
-Trigger TF validation on 2026-05-22T18:18:52Z
+Trigger TF validation on 2026-05-22T18:27:40Z


### PR DESCRIPTION
Forcing TF validation for gke-k8s-rbac-manager to test the post-merge README generation. Closes #409