### PR TITLE
Fix #411: Force full install and verify gke-k8s-rbac-manager for KCC path

### DIFF
--- a/templates/gke-k8s-rbac-manager/.kcc-unsupported
+++ b/templates/gke-k8s-rbac-manager/.kcc-unsupported
@@ -1,1 +1,0 @@
-Temporarily skip KCC path for TF sequential validation

--- a/templates/gke-k8s-rbac-manager/README.md
+++ b/templates/gke-k8s-rbac-manager/README.md
@@ -41,7 +41,7 @@ This template supports two deployment paths that provision equivalent infrastruc
 **Prerequisites:** `terraform` ≥ 1.5, `helm` ≥ 3.10, `kubectl`, `gcloud` with ADC configured.
 
 ```bash
-cd templates/k8s-rbac-manager/terraform-helm
+cd templates/gke-k8s-rbac-manager/terraform-helm
 
 # Initialize
 terraform init
@@ -57,7 +57,7 @@ terraform apply -var="project_id=YOUR_PROJECT_ID"
 **Prerequisites:** A running GKE cluster with Config Connector installed.
 
 ```bash
-cd templates/k8s-rbac-manager/config-connector
+cd templates/gke-k8s-rbac-manager/config-connector
 
 # Apply the manifests
 kubectl apply -f .
@@ -70,12 +70,8 @@ kubectl apply -f .
 Run the validation script:
 
 ```bash
-./templates/k8s-rbac-manager/validate.sh
+./templates/gke-k8s-rbac-manager/validate.sh
 ```
-
-## Limitations
-
-KCC is temporarily unsupported on this isolation branch.
 
 <!-- CI: validation record appended here by ci-post-merge.yml — do not edit below this line manually -->
 

--- a/templates/gke-k8s-rbac-manager/config-connector/cluster.yaml
+++ b/templates/gke-k8s-rbac-manager/config-connector/cluster.yaml
@@ -12,6 +12,9 @@ metadata:
 spec:
   location: us-central1
   initialNodeCount: 1
+  resourceLabels:
+    project: gcp-template-forge
+    template: gke-k8s-rbac-manager
   networkRef:
     name: gke-k8s-rbac-manager-vpc
   subnetworkRef:

--- a/templates/gke-k8s-rbac-manager/config-connector/nodepool.yaml
+++ b/templates/gke-k8s-rbac-manager/config-connector/nodepool.yaml
@@ -20,4 +20,6 @@ spec:
       - https://www.googleapis.com/auth/cloud-platform
     labels:
       project: gcp-template-forge
+    resourceLabels:
+      project: gcp-template-forge
       template: gke-k8s-rbac-manager

--- a/templates/gke-k8s-rbac-manager/validate.sh
+++ b/templates/gke-k8s-rbac-manager/validate.sh
@@ -35,6 +35,15 @@ echo "Test 2: Node Readiness..."
 kubectl wait nodes --all --for=condition=Ready --timeout=10m
 echo "All nodes are Ready."
 
+# 2.5 Apply KCC Workloads
+if [[ "$CLUSTER_NAME" == *"-kcc" ]]; then
+  echo "Applying KCC Workloads..."
+  DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  kubectl apply -f "$DIR/config-connector-workload/cluster.yaml"
+  kubectl wait --for=condition=Established crd/clusters.example.com --timeout=5m
+  kubectl apply -f "$DIR/config-connector-workload/rbac-manager-config.yaml"
+fi
+
 # 3. Workload Readiness
 echo "Test 3: Workload Readiness (CRD and Custom Resource)..."
 kubectl wait --for=condition=Established crd/clusters.example.com --timeout=5m


### PR DESCRIPTION
This PR was generated by **Overseer** (powered by the gemini-3.1-pro-preview model).

Fixes #411

### Changes:
- Removed `.kcc-unsupported` file to enable the Config Connector path in the CI pipelines for `gke-k8s-rbac-manager`.
- Updated `validate.sh` to detect the KCC path (`CLUSTER_NAME` containing `-kcc`) and explicitly apply the raw Kubernetes manifests from the `config-connector-workload/` directory.
- Fixed directory paths and removed the KCC limitations note in `README.md`.
- Added `resourceLabels` to KCC `ContainerCluster` and `ContainerNodePool` for strict functional parity with the Terraform path.

### Rationale:
The CI pipeline applies `config-connector/` to the KCC Management Cluster. The raw workload manifests in `config-connector-workload/` are not automatically deployed by the CI pipeline for the workload cluster, so they must be applied dynamically by `validate.sh` when running tests. This ensures proper verification of both the infrastructure and workloads during the KCC validation process.