### PR TITLE
feat: implement gke-topo-routing template (closes #450)

### DIFF
--- a/templates/gke-topo-routing/README.md
+++ b/templates/gke-topo-routing/README.md
@@ -1,0 +1,13 @@
+# GKE Topology-Aware Routing
+
+This template provisions a regional Google Kubernetes Engine (GKE) cluster and deploys a test workload spread evenly across multiple availability zones. It configures a Kubernetes Service with Topology-Aware Routing (Topology Aware Hints) enabled, demonstrating how GKE routes traffic natively to keep it within the same zone when possible, thereby reducing cross-zone egress costs and latency.
+
+## Architecture
+- **ComputeNetwork & ComputeSubnetwork**: VPC-native networking setup for GKE.
+- **ContainerCluster**: A regional GKE cluster in `us-central1` with Dataplane V2 enabled (ADVANCED_DATAPATH).
+- **ContainerNodePool**: A node pool spanning across all zones in the region.
+- **Deployment**: A 6-replica NGINX deployment enforcing a 1-skew topology spread constraint across zones.
+- **Service**: A ClusterIP service with `service.kubernetes.io/topology-mode: Auto` to automatically assign endpoint hints based on the deployment spread.
+
+## Validation
+The validation script confirms the workload is deployed and asserts that the `EndpointSlice` controller successfully populated the `hints` fields for the endpoints, indicating topology-aware routing is active.

--- a/templates/gke-topo-routing/config-connector-workload/deployment.yaml
+++ b/templates/gke-topo-routing/config-connector-workload/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: topo-app
+  labels:
+    app: topo-app
+spec:
+  replicas: 6
+  selector:
+    matchLabels:
+      app: topo-app
+  template:
+    metadata:
+      labels:
+        app: topo-app
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: topo-app
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "32Mi"

--- a/templates/gke-topo-routing/config-connector-workload/service.yaml
+++ b/templates/gke-topo-routing/config-connector-workload/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: topo-svc
+  annotations:
+    # Supported in older versions and 1.24+ standard:
+    service.kubernetes.io/topology-aware-hints: "auto"
+    # Modern approach introduced in newer K8s versions:
+    service.kubernetes.io/topology-mode: "Auto"
+spec:
+  selector:
+    app: topo-app
+  ports:
+    - port: 80
+      targetPort: 80

--- a/templates/gke-topo-routing/config-connector/cluster.yaml
+++ b/templates/gke-topo-routing/config-connector/cluster.yaml
@@ -1,0 +1,17 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: topo-cluster
+spec:
+  location: us-central1
+  networkRef:
+    name: topo-network
+  subnetworkRef:
+    name: topo-subnetwork
+  ipAllocationPolicy:
+    clusterSecondaryRangeName: pods
+    servicesSecondaryRangeName: services
+  initialNodeCount: 1
+  removeDefaultNodePool: true
+  # Advanced datapath (Dataplane V2) is recommended for optimized network routing
+  datapathProvider: ADVANCED_DATAPATH

--- a/templates/gke-topo-routing/config-connector/network.yaml
+++ b/templates/gke-topo-routing/config-connector/network.yaml
@@ -1,0 +1,22 @@
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: topo-network
+spec:
+  autoCreateSubnetworks: false
+  routingMode: REGIONAL
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: topo-subnetwork
+spec:
+  region: us-central1
+  networkRef:
+    name: topo-network
+  ipCidrRange: 10.128.0.0/20
+  secondaryIpRange:
+    - rangeName: pods
+      ipCidrRange: 10.8.0.0/14
+    - rangeName: services
+      ipCidrRange: 10.12.0.0/20

--- a/templates/gke-topo-routing/config-connector/nodepool.yaml
+++ b/templates/gke-topo-routing/config-connector/nodepool.yaml
@@ -1,0 +1,13 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerNodePool
+metadata:
+  name: topo-nodepool
+spec:
+  location: us-central1
+  clusterRef:
+    name: topo-cluster
+  initialNodeCount: 1
+  nodeConfig:
+    machineType: e2-standard-2
+    oauthScopes:
+      - https://www.googleapis.com/auth/cloud-platform

--- a/templates/gke-topo-routing/template.yaml
+++ b/templates/gke-topo-routing/template.yaml
@@ -1,0 +1,7 @@
+name: "GKE Topology-Aware Routing"
+shortName: "gke-topo-routing"
+description: "Deploys a regional GKE cluster with topology-aware routing capabilities using Config Connector, and deploys a multi-zonal workload utilizing EndpointSlice topology hints."
+technologies:
+  - "GKE"
+  - "Config Connector"
+  - "Kubernetes"

--- a/templates/gke-topo-routing/validate.sh
+++ b/templates/gke-topo-routing/validate.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+echo "Waiting for topo-app deployment to be ready (replicas distributed across zones)..."
+kubectl wait --for=condition=Available deployment/topo-app --timeout=300s
+
+echo "Checking if EndpointSlice contains topology hints..."
+# The EndpointSlice controller might take a few seconds to calculate and apply hints.
+sleep 15
+
+# Retrieve the EndpointSlice associated with the service and extract the zone hints
+HINTS=$(kubectl get endpointslices -l kubernetes.io/service-name=topo-svc -o jsonpath='{.items[*].endpoints[*].hints.forZones[*].name}')
+
+if [[ -z "$HINTS" ]]; then
+    echo "Error: No topology hints found in EndpointSlice. Topology-aware routing may not be functioning correctly."
+    echo "Dumping EndpointSlice state for debugging:"
+    kubectl get endpointslices -l kubernetes.io/service-name=topo-svc -o yaml
+    exit 1
+fi
+
+echo "Topology hints are successfully generated for the following zones: $HINTS"
+echo "Validation passed! Topology-aware routing is active."


### PR DESCRIPTION
Closes #450

## Summary
- Template: `gke-topo-routing`
- Parent Epic: #448
- Path: config-connector
- Generated by: Gemma Tier-1