### PR TITLE
feat: implement gke-test-kcc-skip template (closes #466)

### DIFF
--- a/templates/gke-test-kcc-skip/README.md
+++ b/templates/gke-test-kcc-skip/README.md
@@ -1,0 +1,6 @@
+# GKE Test KCC Skip
+
+This template is designed to test the Config Connector (KCC) unsupported/skip path for Epic #447.
+
+## KCC Unsupported Marker
+By placing the `.kcc-unsupported` marker file inside the `config-connector/` directory, this template signals that the KCC path is skipped. The platform should gracefully handle this by falling back to the Terraform path or recording it as skipped.

--- a/templates/gke-test-kcc-skip/config-connector-workload/placeholder.yaml
+++ b/templates/gke-test-kcc-skip/config-connector-workload/placeholder.yaml
@@ -1,0 +1,1 @@
+# No workloads are deployed because the Config Connector path is unsupported/skipped for this template.

--- a/templates/gke-test-kcc-skip/config-connector/.kcc-unsupported
+++ b/templates/gke-test-kcc-skip/config-connector/.kcc-unsupported
@@ -1,0 +1,1 @@
+This template is explicitly marked as unsupported for Config Connector (KCC) because its purpose is to test the KCC skip flow.

--- a/templates/gke-test-kcc-skip/template.yaml
+++ b/templates/gke-test-kcc-skip/template.yaml
@@ -1,0 +1,6 @@
+shortName: gke-test-kcc-skip
+name: GKE Test KCC Skip
+description: A template designed to test the Config Connector (KCC) unsupported/skip path.
+version: 1.0.0
+category: GKE
+provider: ConfigConnector

--- a/templates/gke-test-kcc-skip/validate.sh
+++ b/templates/gke-test-kcc-skip/validate.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+echo "Executing validation for gke-test-kcc-skip..."
+echo "This template is marked as KCC-unsupported. Skipping active infrastructure validation."
+exit 0


### PR DESCRIPTION
Closes #466

## Summary
- Template: `gke-test-kcc-skip`
- Parent Epic: #447
- Path: config-connector
- Generated by: Gemma Tier-1