### PR TITLE
feat: implement gke-rbac template (closes #479)

### DIFF
--- a/templates/gke-k8s-rbac-manager/.tf-unsupported
+++ b/templates/gke-k8s-rbac-manager/.tf-unsupported
@@ -1,0 +1,1 @@
+This template is for the Config Connector path specifically. The Terraform path is implemented separately.

--- a/templates/gke-k8s-rbac-manager/README.md
+++ b/templates/gke-k8s-rbac-manager/README.md
@@ -1,0 +1,17 @@
+# GKE K8s RBAC Manager
+
+This template provisions a GKE cluster with its associated networking infrastructure using Google Cloud Config Connector. 
+It also deploys native Kubernetes RBAC configurations (ServiceAccount, ClusterRole, and ClusterRoleBinding) to demonstrate managing access controls in the cluster.
+
+## Resources Provisioned
+- **Network**: `ComputeNetwork` and `ComputeSubnetwork`
+- **GKE**: `ContainerCluster` and `ContainerNodePool`
+- **Workload**: A mock Deployment running via a specific `ServiceAccount`.
+- **RBAC**: A `ClusterRole` granting restricted view access to standard resources, and a `ClusterRoleBinding` linking it to the `ServiceAccount`.
+
+## Deployment
+1. Apply the GCP infrastructure in `config-connector/` to your Config Connector management cluster.
+2. Wait for the GKE cluster to be fully provisioned.
+3. Authenticate to the newly created GKE cluster.
+4. Apply the Kubernetes resources in `config-connector-workload/` directly to the newly provisioned GKE cluster.
+5. Execute `validate.sh` to confirm the deployment and thoroughly test RBAC permissions.

--- a/templates/gke-k8s-rbac-manager/README.md
+++ b/templates/gke-k8s-rbac-manager/README.md
@@ -15,3 +15,13 @@ It also deploys native Kubernetes RBAC configurations (ServiceAccount, ClusterRo
 3. Authenticate to the newly created GKE cluster.
 4. Apply the Kubernetes resources in `config-connector-workload/` directly to the newly provisioned GKE cluster.
 5. Execute `validate.sh` to confirm the deployment and thoroughly test RBAC permissions.
+
+## Architecture
+The architecture consists of a GKE Standard cluster managed declaratively via GCP Config Connector (KCC). Kubernetes RBAC resources (ServiceAccount, ClusterRole, ClusterRoleBinding) are deployed natively to the workload cluster to secure permissions, enforcing standard SRE Least Privilege Access Controls.
+
+## Limitations
+This template implements the GKE RBAC Manager references using Config Connector (KCC) specifically. The Terraform path is not supported in this template and is tracked separately under the Terraform sub-issue.
+
+<!-- CI: validation record appended here by ci-post-merge.yml — do not edit below this line manually -->
+## Validation Record
+The validation record table will be dynamically appended here by GHA post-merge.

--- a/templates/gke-k8s-rbac-manager/config-connector-workload/rbac.yaml
+++ b/templates/gke-k8s-rbac-manager/config-connector-workload/rbac.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rbac-manager-sa
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: rbac-manager-role
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "configmaps"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rbac-manager-binding
+subjects:
+- kind: ServiceAccount
+  name: rbac-manager-sa
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: rbac-manager-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rbac-manager-test
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rbac-manager-test
+  template:
+    metadata:
+      labels:
+        app: rbac-manager-test
+    spec:
+      serviceAccountName: rbac-manager-sa
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.9

--- a/templates/gke-k8s-rbac-manager/config-connector/cluster.yaml
+++ b/templates/gke-k8s-rbac-manager/config-connector/cluster.yaml
@@ -1,0 +1,12 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: gke-k8s-rbac-manager-cluster
+spec:
+  location: us-central1-a
+  initialNodeCount: 1
+  removeDefaultNodePool: true
+  networkRef:
+    name: gke-k8s-rbac-manager-net
+  subnetworkRef:
+    name: gke-k8s-rbac-manager-subnet

--- a/templates/gke-k8s-rbac-manager/config-connector/network.yaml
+++ b/templates/gke-k8s-rbac-manager/config-connector/network.yaml
@@ -1,0 +1,17 @@
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  name: gke-k8s-rbac-manager-net
+spec:
+  autoCreateSubnetworks: false
+  routingMode: REGIONAL
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  name: gke-k8s-rbac-manager-subnet
+spec:
+  region: us-central1
+  ipCidrRange: 10.10.0.0/16
+  networkRef:
+    name: gke-k8s-rbac-manager-net

--- a/templates/gke-k8s-rbac-manager/config-connector/nodepool.yaml
+++ b/templates/gke-k8s-rbac-manager/config-connector/nodepool.yaml
@@ -1,0 +1,12 @@
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerNodePool
+metadata:
+  name: gke-k8s-rbac-manager-nodepool
+spec:
+  location: us-central1-a
+  clusterRef:
+    name: gke-k8s-rbac-manager-cluster
+  nodeCount: 1
+  nodeConfig:
+    machineType: e2-medium
+    diskSizeGb: 50

--- a/templates/gke-k8s-rbac-manager/template.yaml
+++ b/templates/gke-k8s-rbac-manager/template.yaml
@@ -1,0 +1,6 @@
+name: gke-k8s-rbac-manager
+shortName: gke-rbac
+description: "GKE cluster with Kubernetes RBAC management setup"
+variants:
+  - name: config-connector
+    path: config-connector

--- a/templates/gke-k8s-rbac-manager/validate.sh
+++ b/templates/gke-k8s-rbac-manager/validate.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+PROJECT_ID=$(gcloud config get-value project)
+CLUSTER_NAME="gke-k8s-rbac-manager-cluster"
+ZONE="us-central1-a"
+
+echo "Retrieving GKE credentials..."
+gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${ZONE}" --project "${PROJECT_ID}"
+
+echo "Waiting for test deployment to be available..."
+kubectl wait --for=condition=available --timeout=300s deployment/rbac-manager-test -n default
+
+echo "Verifying RBAC resources are present..."
+kubectl get serviceaccount rbac-manager-sa -n default
+kubectl get clusterrole rbac-manager-role
+kubectl get clusterrolebinding rbac-manager-binding
+
+echo "Testing RBAC functionality with 'auth can-i'..."
+
+CAN_I_PODS=$(kubectl auth can-i list pods --as=system:serviceaccount:default:rbac-manager-sa)
+if [ "${CAN_I_PODS}" = "yes" ]; then
+    echo "✅ RBAC Test Passed: ServiceAccount CAN list pods."
+else
+    echo "❌ RBAC Test Failed: ServiceAccount CANNOT list pods."
+    exit 1
+fi
+
+CAN_I_SECRETS=$(kubectl auth can-i list secrets --as=system:serviceaccount:default:rbac-manager-sa)
+if [ "${CAN_I_SECRETS}" = "no" ]; then
+    echo "✅ RBAC Test Passed: ServiceAccount CANNOT list secrets."
+else
+    echo "❌ RBAC Test Failed: ServiceAccount CAN list secrets (should be denied)."
+    exit 1
+fi
+
+echo "All tests completed successfully!"


### PR DESCRIPTION
Closes #479

## Summary
- Template: `gke-rbac`
- Parent Epic: #441
- Path: config-connector
- Generated by: Gemma Tier-1